### PR TITLE
wrapAndUnwrapSOL with destinationTokenAccount

### DIFF
--- a/openapi/quoteV6.yaml
+++ b/openapi/quoteV6.yaml
@@ -241,7 +241,7 @@ components:
           description: The user public key.
           type: string
         wrapAndUnwrapSol:
-          description: Default is true. If true, will automatically wrap/unwrap SOL. If false, it will use wSOL token account.  Will be ignored if `destination_token_account` is set because the `destination_token_account` may belong to a different user that we have no authority to close.
+          description: Default is true. If true, will automatically wrap/unwrap SOL. If false, it will use wSOL token account.  Will be ignored if `destinationTokenAccount` is set because the `destinationTokenAccount` may belong to a different user that we have no authority to close.
           type: boolean
         useSharedAccounts:
           description: Default is true. This enables the usage of shared program accountns. That means no intermediate token accounts or open orders accounts need to be created for the users. But it also means that the likelihood of hot accounts is higher.

--- a/openapi/quoteV6.yaml
+++ b/openapi/quoteV6.yaml
@@ -29,6 +29,7 @@ paths:
         - $ref: '#/components/parameters/AmountParameter'
         - $ref: '#/components/parameters/SlippageParameter'
         - $ref: '#/components/parameters/SwapModeParameter'
+        - $ref: '#/components/parameters/DexesParameter'
         - $ref: '#/components/parameters/ExcludeDexesParameter'
         - $ref: '#/components/parameters/OnlyDirectRoutesParameter'
         - $ref: '#/components/parameters/AsLegacyTransactionParameter'
@@ -373,6 +374,7 @@ components:
         enum: ['ExactIn', 'ExactOut']
     DexesParameter:
       name: dexes
+      description: Default is that all DEXes are included. You can pass in the DEXes that you want to include only and separate them by `,`. You can check out the full list [here](https://quote-api.jup.ag/v6/program-id-to-label).
       in: query
       schema:
         type: array
@@ -380,13 +382,12 @@ components:
           type: string
     ExcludeDexesParameter:
       name: excludeDexes
-      description: Default is that all DEXes are included. You can pass in the DEXes that you want to exclude and separate them by `,`.
+      description: Default is that all DEXes are included. You can pass in the DEXes that you want to exclude and separate them by `,`. You can check out the full list [here](https://quote-api.jup.ag/v6/program-id-to-label).
       in: query
       schema:
         type: array
         items:
           type: string
-          enum: ["Aldrin", "Aldrin V2", "Balansol", "Crema", "Cropper", "FluxBeam", "Lifinity V1", "Lifinity V2", "Oasis", "Bonkswap", "Marinade", "Mercurial", "Meteora", "Phoenix", "Raydium", "Raydium CLMM", "Saber", "Saber (Decimals)", "Openbook", "Saros", "Orca V2", "StepN", "Orca V1", "Penguin", "Symmetry", "Whirlpool", "Invariant", "Helium Network", "Jupiter LO", "Sanctum"]
     OnlyDirectRoutesParameter:
       name: onlyDirectRoutes
       description: Default is false. Direct Routes limits Jupiter routing to single hop routes only.

--- a/openapi/quoteV6.yaml
+++ b/openapi/quoteV6.yaml
@@ -241,7 +241,7 @@ components:
           description: The user public key.
           type: string
         wrapAndUnwrapSol:
-          description: Default is true. If true, will automatically wrap/unwrap SOL. If false, it will use wSOL token account.
+          description: Default is true. If true, will automatically wrap/unwrap SOL. If false, it will use wSOL token account.  Will be ignored if `destination_token_account` is set because the `destination_token_account` may belong to a different user that we have no authority to close.
           type: boolean
         useSharedAccounts:
           description: Default is true. This enables the usage of shared program accountns. That means no intermediate token accounts or open orders accounts need to be created for the users. But it also means that the likelihood of hot accounts is higher.


### PR DESCRIPTION
if `destinationTokenAccount` is set, `wrapAndUnwrapSol` will be ignored.

also, added the missing `dexes` parameter on v6 API documentation.