### PR TITLE
Add RPC Providers to Self-hosted V6 Swap API Doc

### DIFF
--- a/docs/2-apis/8-self-hosted.md
+++ b/docs/2-apis/8-self-hosted.md
@@ -4,7 +4,7 @@ description: "Run the swap API with your own infra"
 title: "Self-hosted V6 Swap API"
 ---
 
-Advanced users can run a self-hosted Jupiter Swap API, you can download the jupiter-swap-api [here](https://github.com/jup-ag/jupiter-swap-api/releases).
+Advanced users can run a self-hosted Jupiter Swap API, you can download the jupiter-swap-api [here](https://github.com/jup-ag/jupiter-swap-api/releases). Alternatively, users can contact an RPC provider such as [Helius](https://www.helius.dev/) or [Triton](https://triton.one/) to set up a gRPC node with Jupiter's Swap API.
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR aims to enhance the Self-hosted V6 Swap API documentation by introducing additional options for advanced users. Specifically, it adds information about RPC providers such as Helius and Triton, who offer services to set up a gRPC node with Jupiter's Swap API