### PR TITLE
RACX-161 Example for DCA isn't right

### DIFF
--- a/guides/4-dca/2-how-dca-work.md
+++ b/guides/4-dca/2-how-dca-work.md
@@ -51,7 +51,7 @@ You will receive purchased tokens in your wallet within the same transaction of 
 
 As an example, say you opt to DCA into SOL with $900 USDC over 3 days, with SOL being the purchase token.
 
-- On Day 1, you will receive $300 USDC worth of SOL in your wallet automatically. If the price of SOL is $30 USDC / SOL, you will receive 29.97 SOL *(net of fees)* in your wallet.
+- On Day 1, you will receive $300 USDC worth of SOL in your wallet automatically. If the price of SOL is $30 USDC / SOL, you will receive 9.97 SOL *(net of fees)* in your wallet.
 - On Day 2, you will receive $300 USDC worth of SOL in your wallet. If the price of SOL is $25 USDC / SOL, you will receive 11.988 SOL *(net of fees)* in your wallet.
 - On Day 3, you will receive $300 USDC worth of SOL in your wallet. If the price of SOL stay stagnant and remain as $25 USDC / SOL, you will receive 11.988 SOL *(net of fees)* in your wallet.
 


### PR DESCRIPTION
It should be:

> you will receive 9.97 SOL (net of fees) in your wallet.

because $30 USDC / SOL.