### PR TITLE
Add third party hosted API

### DIFF
--- a/docs/2-apis/8-self-hosted.md
+++ b/docs/2-apis/8-self-hosted.md
@@ -74,9 +74,9 @@ Then:
 
 This will start the API server without Openbook as part of routing. You can also remove individual market as well.
 
-## Free Third Party Hosted APIs
+## Third Party Hosted APIs
 
-Our collaboration with some Solana RPC partners in the ecosystem allows you to take advantage of a hosted API they provide for free.
+Our collaboration with some Solana RPC partners in the ecosystem allows you to take advantage of a hosted API they provide for free or a small fee.
 
 - Jupiter API Powered by QuickNode: https://www.jupiterapi.com 
   - Endpoint: `https://public.jupiterapi.com`

--- a/docs/2-apis/8-self-hosted.md
+++ b/docs/2-apis/8-self-hosted.md
@@ -74,6 +74,14 @@ Then:
 
 This will start the API server without Openbook as part of routing. You can also remove individual market as well.
 
+## Free Third Party Hosted APIs
+
+Our collaboration with some Solana RPC partners in the ecosystem allows you to take advantage of a hosted API they provide for free.
+
+- Jupiter API Powered by QuickNode: https://www.jupiterapi.com 
+  - Endpoint: `https://public.jupiterapi.com`
+
+
 ## Paid Hosted APIs
 
 We are working with some Solana RPC partners in the ecosystem as well so that you can get a paid hosted API ran by them.


### PR DESCRIPTION
We hosted a free instance of [Metis - Jupiter V6 Swap API](https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api) that takes a 0.2% platform fee on swaps for those that aren't willing to self host, yet run into rate limit or latency issues with `https://quote-api.jup.ag/v6`.

It offers:
- Up to 50 requests/sec
- 80ms Latency or faster
- Hosted in Ashburn, Virginia (US East region) for those that want to co-locate in order to reduce latency

More information can be found at [https://www.jupiterapi.com/](https://www.jupiterapi.com/)

 