### PR TITLE
swap and limit order api docs update

### DIFF
--- a/docs/2-apis/1-swap-api.md
+++ b/docs/2-apis/1-swap-api.md
@@ -216,13 +216,20 @@ transaction.sign([wallet.payer]);
 #### 7. Execute the transaction
 
 ```js
+// get the latest block hash
+const latestBlockHash = await connection.getLatestBlockhash();
+
 // Execute the transaction
 const rawTransaction = transaction.serialize()
 const txid = await connection.sendRawTransaction(rawTransaction, {
   skipPreflight: true,
   maxRetries: 2
 });
-await connection.confirmTransaction(txid);
+await connection.confirmTransaction({
+ blockhash: latestBlockHash.blockhash,
+ lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
+ signature: txid
+});
 console.log(`https://solscan.io/tx/${txid}`);
 ```
 

--- a/docs/3-limit-order/1-limit-order-api.md
+++ b/docs/3-limit-order/1-limit-order-api.md
@@ -113,13 +113,20 @@ transaction.sign([wallet.payer, base]);
 **6. Execute the transaction**
 
 ```js
+// get the latest block hash
+const latestBlockHash = await connection.getLatestBlockhash();
+
 // Execute the transaction
 const rawTransaction = transaction.serialize();
 const txid = await connection.sendRawTransaction(rawTransaction, {
   skipPreflight: true,
   maxRetries: 2,
 });
-await connection.confirmTransaction(txid);
+await connection.confirmTransaction({
+  blockhash: latestBlockHash.blockhash,
+  lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
+  signature: txid
+});
 console.log(`https://solscan.io/tx/${txid}`);
 ```
 


### PR DESCRIPTION
Updated the documentation to reflect the changes in the confirmTransaction function parameters. The function requires a `TransactionConfirmationStrategy` instead of a `TransactionSignature`. The previous usage with `TransactionSignature` is deprecated.