### PR TITLE
Update 1-swap-api.md

### DIFF
--- a/docs/2-apis/1-swap-api.md
+++ b/docs/2-apis/1-swap-api.md
@@ -98,7 +98,8 @@ Get the best swap routes for a token trade pair sorted by largest output token a
 | `platformFeeBps`  | Integer | No       | If you want to charge the user a fee, you can specify the fee in BPS. Fee % is taken out of the output token.|
 | `onlyDirectRoutes`    | Boolean | No       | Default is false. Direct Routes limits Jupiter routing to single hop routes only.  |
 | `asLegacyTransaction`    | Boolean | No       | Default is false. Instead of using versioned transaction, this will use the legacy transaction. |
-| `excludeDexes`    | Array | No | Default is that all DEXes are included. You can pass in the DEXes that you want to exclude and separate them by `,`. For example, `Aldrin,Saber`. |
+| `dexes`    | String | No | Only these DEXes you pass in will be considered when getting a route. You pass in these DEXes and separate them by `,`.  For example, `Aldrin,Saber`. |
+| `excludeDexes`    | String | No | Default is that all DEXes are included. You can pass in the DEXes that you want to exclude and separate them by `,`. For example, `Aldrin,Saber`. |
 | `maxAccounts` | Integer | No | Find a route given a maximum number of accounts involved, this might dangerously limit routing ending up giving a bad price. The max is an estimation and not the exact count. |
 
 :::tip Platform Fee

--- a/docs/2-apis/1-swap-api.md
+++ b/docs/2-apis/1-swap-api.md
@@ -102,6 +102,30 @@ Get the best swap routes for a token trade pair sorted by largest output token a
 | `excludeDexes`    | String | No | Default is that all DEXes are included. You can pass in the DEXes that you want to exclude and separate them by `,`. For example, `Aldrin,Saber`. |
 | `maxAccounts` | Integer | No | Find a route given a maximum number of accounts involved, this might dangerously limit routing ending up giving a bad price. The max is an estimation and not the exact count. |
 
+:::info The `dexes` and `excludeDexes` parameters can not be set at the same time. If they are both set you will receive an invalid request error. Below is an example of this. :::
+
+```shell
+curl -s 'https://quote-api.jup.ag/v6/quote?inputMint=So11111111111111111111111111111111111111112&outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&amount=1000000&slippageBps=1&dexes=Raydium,Whirlpool&excludeDexes=Saber' | jq
+```
+***Response***
+
+  <details>
+    <summary>
+      <span style={{color: '#018847'}}>&bull; </span>
+      <span style={{fontSize: '14px'}}>
+      <b style={{color: '#ff0000', marginRight: '36px'}}>400: Bad Request</b>
+        Error Response
+      </span>
+    </summary>
+
+```json
+{
+  "errorCode": "INVALID_REQUEST",
+  "error": "Cannot set dexes and exclude dexes at the same time"
+}
+```
+</details>
+
 :::tip Platform Fee
 If you'd like to charge a fee, pass in `platformFeeBps` as a parameter in the quote.
 :::


### PR DESCRIPTION
- The Type for `excludeDexes` should be `String` and not `Array`.
- The `/quote` endpoint supports a `dexes` request parameter which was not documented.

If the `excludeDexes` Type should truly be `Array` then the `routePlan` of the `/quote` response of the below `curl` request should only include the `Raydium` or `Whirlpool` DEXes (`Raydium` and `Whirlpool` are the only DEXes not included in the below `curl` request). As you can see below, the `routePlan` includes other DEXes.

```shell
curl -v -G \
  --data-urlencode "excludeDexes=Lifinity V2" \
  --data-urlencode "excludeDexes=Helium Network" \
  --data-urlencode "excludeDexes=Raydium CLMM" \
  --data-urlencode "excludeDexes=Saber" \
  --data-urlencode "excludeDexes=StepN" \
  --data-urlencode "excludeDexes=Meteora" \
  --data-urlencode "excludeDexes=Aldrin V2" \
  --data-urlencode "excludeDexes=Saber (Decimals)" \
  --data-urlencode "excludeDexes=Invariant" \
  --data-urlencode "excludeDexes=Clone%20Protocol" \
  --data-urlencode "excludeDexes=Bonkswap" \
  --data-urlencode "excludeDexes=Orca V1" \
  --data-urlencode "excludeDexes=Sanctum Infinity" \
  --data-urlencode "excludeDexes=Aldrin" \
  --data-urlencode "excludeDexes=FluxBeam" \
  --data-urlencode "excludeDexes=GooseFX" \
  --data-urlencode "excludeDexes=Perps" \
  --data-urlencode "excludeDexes=Meteora DLMM" \
  --data-urlencode "excludeDexes=Oasis" \
  --data-urlencode "excludeDexes=Phoenix" \
  --data-urlencode "excludeDexes=Mercurial" \
  --data-urlencode "excludeDexes=Sanctum" \
  --data-urlencode "excludeDexes=Marinade" \
  --data-urlencode "excludeDexes=OpenBook V2" \
  --data-urlencode "excludeDexes=Orca V2" \
  --data-urlencode "excludeDexes=Cropper" \
  --data-urlencode "excludeDexes=Lifinity V1" \
  --data-urlencode "excludeDexes=Raydium CP" \
  --data-urlencode "excludeDexes=Token Swap" \
  --data-urlencode "excludeDexes=Saros" \
  --data-urlencode "excludeDexes=Penguin" \
  --data-urlencode "excludeDexes=Crema" \
  --data-urlencode "excludeDexes=Openbook" \
  --data-urlencode "excludeDexes=Dexlab" \
  --data-urlencode "excludeDexes=Cropper Legacy" \
  https://quote-api.jup.ag/v6/quote\?inputMint\=So11111111111111111111111111111111111111112\&outputMint\=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\&amount\=1000000\&slippageBps\=1 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 104.18.43.59:443...
* Connected to quote-api.jup.ag (104.18.43.59) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4205 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=jup.ag
*  start date: May 12 20:10:47 2024 GMT
*  expire date: Aug 10 20:10:46 2024 GMT
*  subjectAltName: host "quote-api.jup.ag" matched cert's "*.jup.ag"
*  issuer: C=US; O=Google Trust Services LLC; CN=GTS CA 1P5
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fcc62012c00)
> GET /v6/quote?inputMint=So11111111111111111111111111111111111111112&outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&amount=1000000&slippageBps=1&excludeDexes=Lifinity+V2&excludeDexes=Helium+Network&excludeDexes=Raydium+CLMM&excludeDexes=Saber&excludeDexes=StepN&excludeDexes=Meteora&excludeDexes=Aldrin+V2&excludeDexes=Saber+%28Decimals%29&excludeDexes=Invariant&excludeDexes=Clone%2520Protocol&excludeDexes=Bonkswap&excludeDexes=Orca+V1&excludeDexes=Sanctum+Infinity&excludeDexes=Aldrin&excludeDexes=FluxBeam&excludeDexes=GooseFX&excludeDexes=Perps&excludeDexes=Meteora+DLMM&excludeDexes=Oasis&excludeDexes=Phoenix&excludeDexes=Mercurial&excludeDexes=Sanctum&excludeDexes=Marinade&excludeDexes=OpenBook+V2&excludeDexes=Orca+V2&excludeDexes=Cropper&excludeDexes=Lifinity+V1&excludeDexes=Raydium+CP&excludeDexes=Token+Swap&excludeDexes=Saros&excludeDexes=Penguin&excludeDexes=Crema&excludeDexes=Openbook&excludeDexes=Dexlab&excludeDexes=Cropper+Legacy HTTP/2
> Host: quote-api.jup.ag
> user-agent: curl/7.79.1
> accept: */*
> 
< HTTP/2 200 
< date: Tue, 02 Jul 2024 18:46:45 GMT
< content-type: application/json
< content-length: 1341
< cf-ray: 89d0cce15af1ce6c-SJC
< cf-cache-status: DYNAMIC
< access-control-allow-origin: *
< access-control-allow-headers: *
< access-control-max-age: 86400
< access-control-request-method: GET, POST, OPTIONS
< m: 
< server: cloudflare
< alt-svc: h3=":443"; ma=86400
< 
{ [1341 bytes data]
100  1341  100  1341    0     0   1384      0 --:--:-- --:--:-- --:--:--  1392
* Connection #0 to host quote-api.jup.ag left intact
{
  "inputMint": "So11111111111111111111111111111111111111112",
  "inAmount": "1000000",
  "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
  "outAmount": "153063",
  "otherAmountThreshold": "153048",
  "swapMode": "ExactIn",
  "slippageBps": 1,
  "platformFee": null,
  "priceImpactPct": "0",
  "routePlan": [
    {
      "swapInfo": {
        "ammKey": "STK75uPSyBnEhGTTzb1nwmP3n427XoXmfRhXxxhyady",
        "label": "Saber",
        "inputMint": "So11111111111111111111111111111111111111112",
        "outputMint": "bSo13r4TkiE4KumL71LsHTPpL2euBYLFx6h9HP3piy1",
        "inAmount": "1000000",
        "outAmount": "877959",
        "feeAmount": "87",
        "feeMint": "bSo13r4TkiE4KumL71LsHTPpL2euBYLFx6h9HP3piy1"
      },
      "percent": 100
    },
    {
      "swapInfo": {
        "ammKey": "6cDtJkcJKFEsGDhptmgvy3XtbwyRqnW3GoGcmnwVzJ7U",
        "label": "Meteora DLMM",
        "inputMint": "bSo13r4TkiE4KumL71LsHTPpL2euBYLFx6h9HP3piy1",
        "outputMint": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
        "inAmount": "877959",
        "outAmount": "176017",
        "feeAmount": "2634",
        "feeMint": "bSo13r4TkiE4KumL71LsHTPpL2euBYLFx6h9HP3piy1"
      },
      "percent": 100
    },
    {
      "swapInfo": {
        "ammKey": "4Ui9QdDNuUaAGqCPcDSp191QrixLzQiLxJ1Gnqvz3szP",
        "label": "Whirlpool",
        "inputMint": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
        "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
        "inAmount": "176017",
        "outAmount": "153063",
        "feeAmount": "0",
        "feeMint": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN"
      },
      "percent": 100
    }
  ],
  "contextSlot": 275301442,
  "timeTaken": 0.228341121
}
```


The list of DEXes was retrieved from this, `curl -L 'https://quote-api.jup.ag/v6/program-id-to-label' \
-H 'Accept: application/json' | jq`, command.