### PR TITLE
added risk disclaimer to v6 swap api docs

### DIFF
--- a/docs/2-apis/1-swap-api.md
+++ b/docs/2-apis/1-swap-api.md
@@ -10,13 +10,17 @@ title: "V6 Swap API"
 
 Jupiter APIs is the easiest way for developers to access liquidity on Solana. Simply pass in the desired pairs, amount, and slippage, and the API will return the serialized transactions needed to execute the swap, which can then be passed into the Solana blockchain with the required signatures.
 
+:::info Risk Disclaimer
+**Please use Jupiter's Swap API at your own risk**. [Jupiter's Frontend UI](https://jup.ag/) contains multiple safeguards and warnings when quoting. Jupiter is not liable for losses incurred by users on other platforms.
+:::
+
 ## V6 API Reference
 
 All Jupiter swaps are using versioned transactions and address lookup tables. But not all wallets support Versioned Transactions yet, so if you detect a wallet that does not support versioned transactions, you will need to use the `asLegacyTransaction` parameter.
 
 Learn more about the Jupiter API Documentation at the [OpenAPI documentation](/api-v6). This documentation has a REST request list and a built in API Playground. Use the API Playground to try API calls now!
 
-:::info API Documentation
+:::tip API Documentation
  [OpenAPI Documentation](/api-v6)
 :::
 


### PR DESCRIPTION
This PR contains the following changes:

1. Added risk disclaimer to V6 Swap API documentation
2. Edited OpenAPI documentation ::info to ::tip for consistency