### PR TITLE
Add QuickNode Yellowstone gRPC plugin to self hosted

### DIFF
--- a/docs/2-apis/9-self-hosted.md
+++ b/docs/2-apis/9-self-hosted.md
@@ -25,6 +25,7 @@ The following RPC providers can provide a RPC node with the geyser plugin:
 - [Triton](https://triton.one)
 - [Helius](https://docs.helius.dev) Contact Helius on [Discord](https://discord.com/invite/6GXdee3gBj)
 - [Shyft](https://shyft.to/#solana_grpc_streaming_service) Contact Shyft on [Discord](https://discord.gg/8JyZCjRPmr)
+- [QuickNode](https://marketplace.quicknode.com/add-on/yellowstone-grpc)
 
 ## Usage
 


### PR DESCRIPTION
Adds a link to QuickNode's Yellowstone gRPC plugin to the self hosted page