### PR TITLE
Update docs URL for Metropolis landing page

### DIFF
--- a/src/components/Metropolis/constants.ts
+++ b/src/components/Metropolis/constants.ts
@@ -1,1 +1,1 @@
-export const DOCS_URL = "https://docs.jup.ag";
+export const DOCS_URL = "https://station.jup.ag/docs";


### PR DESCRIPTION
Change links that point from docs.jup.ag to https://station.jup.ag/docs in Metropolis landing page