### PR TITLE
Update docs to mention that hourly borrow rates are dynamic

### DIFF
--- a/guides/7-jlp/2-How-JLP-Works.md
+++ b/guides/7-jlp/2-How-JLP-Works.md
@@ -57,16 +57,16 @@ It is essential to note that pool earnings and losses (index token appreciation/
 
 ### Fee Calculations
 
-| Action             | Fee                                                                        |
-| ------------------ | -------------------------------------------------------------------------- |
-| Opening a Position | 6 BPS                                                                      |
-| Closing a Position | 6 BPS                                                                      |
+| Action             | Fee                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------|
+| Opening a Position | 6 BPS                                                                                  |
+| Closing a Position | 6 BPS                                                                                  |
 | Price Impact Fee   | Variable (see [reference](../8-perpetual-exchange/2-how-it-works.md#price-impact-fee)) |
-| Swap Fee           | Between 0 BPS to 150 BPS depending on pool weightage                       |
-| Borrow Rate        | 0.8 / 1.0 BPS per hour (see below) x token utilization percentage                    |
+| Swap Fee           | Between 0 BPS to 150 BPS depending on pool weightage                                   |
+| Borrow Rate        | Dynamically updated based on utilization and market conditions (see below)             |
 
 :::info
-**Hourly Borrow Rate** is set at 0.012% for SOL and BTC, 0.008% for ETH, and 0.01% for USDC and USDT.
+The hourly borrow rate is updated dynamically depending on utilization and market conditions. You can view the current hourly borrow rate in the `Borrow rate` field of the Jupiter Perpetuals trade form or retrieved onchain via the [custody account's `funding_rate_state.hourly_funding_dbps` field](https://station.jup.ag/guides/perpetual-exchange/onchain-accounts#custody-account).
 :::
 
 Fee calculation for opening and closing positions involves the volume of these transactions, multiplied by the fee percentage of 0.06%.

--- a/guides/8-perpetual-exchange/2-how-it-works.md
+++ b/guides/8-perpetual-exchange/2-how-it-works.md
@@ -314,13 +314,7 @@ The formula for the hourly borrow fee is:
 
 ![hourly-borrow-fee](./hourly-borrow-fee.png)
 
-The hourly borrow rates for the JLP assets are as follows:
-
-- SOL and BTC: 0.012%
-- ETH: 0.008%
-- USDC and USDT: 0.01%
-
-These rates represent the maximum charged at **100% utilization**. In practice, as utilization for the tokens are usually below 100%, the actual hourly borrow rates are often **lower**.
+The hourly borrow rates for JLP assets can be retrieved from the `Borrow rate` field of the Jupiter Perpetuals trade form or fetched onchain via the [custody account's `funding_rate_state.hourly_funding_dbps` field](https://station.jup.ag/guides/perpetual-exchange/onchain-accounts#custody-account). Note that these rates represent the maximum charged at **100% utilization**.
 
 #### Calculating Utilization Rate
 
@@ -346,7 +340,7 @@ Read more about how the base rate for each token is decided from [Gauntlet's rec
 
 #### Worked Example
 
-For example, assume the price of SOL is **$100**. The SOL liquidity pool has **1,000 SOL** under custody, and has lent out **100 SOL** (i.e. it's utilization is 10%). A trader opens a **100 SOL** position with an initial margin of **10 SOL**. The remaining **90 SOL** is borrowed from the pool to open the leveraged position.
+For example, assume the price of SOL is **$100**. The SOL liquidity pool has **1,000 SOL** under custody and has lent out **100 SOL** (i.e, utilization is 10%). A trader opens a **100 SOL** position with an initial margin of **10 SOL**. The remaining **90 SOL** is borrowed from the pool to open the leveraged position. Assume that the hourly borrow rate for SOL is **0.012%**:
 
 * `Position Size in SOL`: 100 SOL
 * `Total Tokens Locked`: ` 100 SOL (position size) + 100 SOL (utilized SOL in pool) = 200 SOL
@@ -449,7 +443,7 @@ At the same time, a minor SOL amount will be used for rent to create an escrow a
 
 With all these concepts covered, let's go through a worked example.
 
-Suppose a trader wants to open a 2x long SOL position at a position size of $1000 USD by depositing $500 USD worth of SOL as a collateral and borrowing $500 USD worth of SOL from the pool.
+Suppose a trader wants to open a 2x long SOL position at a position size of $1000 USD by depositing $500 USD worth of SOL as a collateral and borrowing $500 USD worth of SOL from the pool. Assume the hourly borrow rate for SOL is **0.012%**.
 
 | Initial Position Value | $1000 |
 | --- | ----- |

--- a/guides/8-perpetual-exchange/2-how-it-works.md
+++ b/guides/8-perpetual-exchange/2-how-it-works.md
@@ -314,7 +314,9 @@ The formula for the hourly borrow fee is:
 
 ![hourly-borrow-fee](./hourly-borrow-fee.png)
 
+:::info
 The hourly borrow rates for JLP assets can be retrieved from the `Borrow rate` field of the Jupiter Perpetuals trade form or fetched onchain via the [custody account's `funding_rate_state.hourly_funding_dbps` field](https://station.jup.ag/guides/perpetual-exchange/onchain-accounts#custody-account). Note that these rates represent the maximum charged at **100% utilization**.
+:::
 
 #### Calculating Utilization Rate
 


### PR DESCRIPTION
With the increased utilization, we may change the hourly borrow rates for perps and it's cumbersome to update the docs each time. Instead, we say that the borrow rate may change subject to utilization and market conditions. I also updated the calculations to use an assumed hourly borrow rate, instead of stating that this is the current borrow rate.