### PR TITLE
chore: [trigger] remove verify-token endpoint

### DIFF
--- a/api-reference/trigger/verify-token.mdx
+++ b/api-reference/trigger/verify-token.mdx
@@ -1,5 +1,0 @@
----
-title: "Verify Token"
-description: "Verify a JWT token is still valid"
-openapi: /openapi-spec/trigger/v2/trigger.yaml post /auth/verify-token
----

--- a/docs.json
+++ b/docs.json
@@ -324,7 +324,6 @@
                     "pages": [
                       "api-reference/trigger/challenge",
                       "api-reference/trigger/verify",
-                      "api-reference/trigger/verify-token",
                       "api-reference/trigger/vault",
                       "api-reference/trigger/vault-register"
                     ]

--- a/llms.txt
+++ b/llms.txt
@@ -259,7 +259,6 @@ Vault-based limit orders with single, OCO (TP/SL), and OTOCO order types.
 
 - [Request Challenge](https://dev.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml): Request a sign-in challenge for wallet authentication
 - [Verify Challenge](https://dev.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml): Submit the signed challenge to receive a JWT token
-- [Verify Token](https://dev.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml): Verify a JWT token is still valid
 - [Get Vault](https://dev.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml): Get vault information and balance for an account
 - [Register Vault](https://dev.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml): Register a new trigger vault for the account
 

--- a/openapi-spec/trigger/v2/trigger.yaml
+++ b/openapi-spec/trigger/v2/trigger.yaml
@@ -270,47 +270,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /auth/verify-token:
-    post:
-      summary: Verify JWT token validity
-      description: Check if a JWT token is still valid without making an authenticated request.
-      security:
-        - ApiKeyAuth: []
-          BearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                walletPubkey:
-                  type: string
-              required:
-                - walletPubkey
-      responses:
-        '200':
-          description: Token is valid
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  isValid:
-                    type: boolean
-                required:
-                  - isValid
-              example:
-                isValid: true
-        '400':
-          description: Invalid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '403':
-          description: Token does not match wallet
-
   /vault:
     get:
       summary: Get vault info

--- a/portal/plans.mdx
+++ b/portal/plans.mdx
@@ -76,7 +76,6 @@ Credit costs are subject to change. The latest costs are always reflected in you
     | :--- | :--- |
     | `/trigger/v2/auth/challenge` | 1 |
     | `/trigger/v2/auth/verify` | 1 |
-    | `/trigger/v2/auth/verify-token` | 1 |
     | `/trigger/v2/vault` | 1 |
     | `/trigger/v2/vault/register` | 1 |
     | `/trigger/v2/deposit/craft` | 1 |

--- a/trigger/authentication.mdx
+++ b/trigger/authentication.mdx
@@ -163,21 +163,3 @@ An attacker **cannot**:
 
 All operations involving funds (deposits, withdrawals) require the wallet owner to sign a transaction. A leaked JWT alone cannot result in loss of funds. However, if the wallet private key is also compromised, an attacker could sign transactions and withdraw funds from the vault.
 
-## Verify Token (Optional)
-
-To check if a token is still valid without making an authenticated request:
-
-```typescript
-const verifyTokenResponse = await fetch('https://api.jup.ag/trigger/v2/auth/verify-token', {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    'x-api-key': 'your-api-key',
-    'Authorization': `Bearer ${token}`,
-  },
-  body: JSON.stringify({
-    walletPubkey: walletAddress,
-  }),
-});
-// Returns 200 if valid, 401 if expired or invalid
-```


### PR DESCRIPTION
## Summary
Removes the `/auth/verify-token` endpoint from Trigger V2 API docs, OpenAPI spec, and all references across the repo.

## Changes
- Deleted `api-reference/trigger/verify-token.mdx`
- Removed from `docs.json` navigation
- Removed endpoint definition from `openapi-spec/trigger/v2/trigger.yaml`
- Removed "Verify Token" section from `trigger/authentication.mdx`
- Removed from `portal/plans.mdx` endpoint credits table
- Regenerated `llms.txt`

## Linear Issues
- Fixes [DEV-209](https://linear.app/raccoons/issue/DEV-209) — remove trigger/verify-token

## Checklist
- [x] `node generate-llms-from-docs.js` run
- [x] `mint broken-links` passes
- [x] All pages have `title`, `description`, `llmsDescription`
- [x] `docs.json` navigation updated
- [x] No remaining references to `verify-token` in repo
