### PR TITLE
feat: [tokens] add stocks tag to /tokens/v2/tag endpoint

### DIFF
--- a/openapi-spec/tokens/v2/tokens.yaml
+++ b/openapi-spec/tokens/v2/tokens.yaml
@@ -119,6 +119,7 @@ paths:
             enum:
               - lst
               - verified
+              - stocks
           required: true
       responses:
         '200':

--- a/tokens/index.mdx
+++ b/tokens/index.mdx
@@ -47,7 +47,7 @@ Higher scores indicate more legitimate, organic trading. Surface this in your UI
 
 ## Token Tags
 
-Token tags are labels applied to tokens for categorisation and discoverability (e.g. `verified`, `lst`, `community`). Tags appear in the Jupiter UI and are available via the [GET /tag](/api-reference/tokens/tag) endpoint.
+Token tags are labels applied to tokens for categorisation and discoverability (e.g. `verified`, `lst`, `stocks`, `community`). Tags appear in the Jupiter UI and are available via the [GET /tag](/api-reference/tokens/tag) endpoint.
 
 To get your tokens tagged:
 1. Host a public CSV endpoint with mint addresses (one per row)
@@ -63,7 +63,7 @@ To get your tokens tagged:
   </Card>
 
   <Card title="Tag" icon="tag" href="/api-reference/tokens/tag">
-    Get tokens by tag (verified, lst, etc.)
+    Get tokens by tag (verified, lst, stocks)
   </Card>
 
   <Card title="Category" icon="chart-line" href="/api-reference/tokens/category">

--- a/tokens/token-information.mdx
+++ b/tokens/token-information.mdx
@@ -46,12 +46,13 @@ const searchResponse = await (
 
 ## Query by Tag
 
-The Tokens API V2 provides an endpoint to query by tags. This is useful to help users distinguish between verified vs non-verified or specific groups of tokens like liquid-staked tokens (LSTs).
+The Tokens API V2 provides an endpoint to query by tags. This is useful to help users distinguish between verified vs non-verified or specific groups of tokens like liquid-staked tokens (LSTs) or tokenized stocks.
 
 <Tip>
   **TAGS**
 
-  * Only `lst` or `verified` tag.
+  * Supported tags: `lst`, `verified`, `stocks`.
+  * `stocks` returns tokenized equities (e.g. Ondo, Remora).
   * Note that this will return the entire array of existing mints that belongs to the tag.
 </Tip>
 


### PR DESCRIPTION
## Summary
Expose the `stocks` tag on `/tokens/v2/tag` so integrators can query tokenized equities (Ondo, Remora, etc.) the same way they query `lst` or `verified`.

## Changes
- `openapi-spec/tokens/v2/tokens.yaml` — add `stocks` to the `/tag` `query` enum
- `tokens/token-information.mdx` — list `stocks` in the supported tags tip with a note on what it covers
- `tokens/index.mdx` — include `stocks` in the Token Tags examples and the API reference card

## Linear Issues
- Fixes [DEV-331](https://linear.app/raccoons/issue/DEV-331/add-a-tag-for-tokenized-stocks-assets) — Add a tag for tokenized stocks assets

## Checklist
- [x] `node generate-llms-from-docs.js` run
- [x] `mint broken-links` passes
- [x] All pages have `title`, `description`, `llmsDescription`
- [ ] `docs.json` navigation updated (not applicable — no new pages)
- [ ] Redirects added (not applicable — no path changes)
- [ ] Changelog entry added to `updates/index.mdx` (not applicable — tag addition to existing endpoint)
- [ ] `.claude/rules/` updated (not applicable)
