### PR TITLE
fix: [plugin] correct CSS variable name from primaryText to primary-text

### DIFF
--- a/tool-kits/plugin/customization.mdx
+++ b/tool-kits/plugin/customization.mdx
@@ -221,7 +221,7 @@ Jupiter Plugin supports a simplified way to customize the color theme. This allo
 :root {
   --jupiter-plugin-primary: 199, 242, 132;
   --jupiter-plugin-background: 0, 0, 0;
-  --jupiter-plugin-primaryText: 232, 249, 255;
+  --jupiter-plugin-primary-text: 232, 249, 255;
   --jupiter-plugin-warning: 251, 191, 36;
   --jupiter-plugin-interactive: 33, 42, 54;
   --jupiter-plugin-module: 16, 23, 31;


### PR DESCRIPTION
## Summary

The Plugin customization docs listed `--jupiter-plugin-primaryText` (camelCase) in the CSS theme example, but the compiled plugin CSS at `plugin.jup.ag` uses `--jupiter-plugin-primary-text` (kebab-case). Setting the camelCase variable has no effect — verified by setting it to `0, 0, 0` (no change) vs the kebab-case version (text turns black).

## Changes

- `tool-kits/plugin/customization.mdx`: rename `--jupiter-plugin-primaryText` → `--jupiter-plugin-primary-text` in the CSS theme example