### PR TITLE
docs: [swap] remove no-fees integration callout from dex-integration page

### DIFF
--- a/swap/routing/dex-integration.mdx
+++ b/swap/routing/dex-integration.mdx
@@ -8,10 +8,6 @@ This guide covers how to integrate your decentralized exchange (DEX) into Jupite
 
 Jupiter is one of the most widely integrated protocols, so a lot of work is involved in minimizing issues on new integrations and making each integration valuable to our users and partners. Our top priority is ensuring security and providing the best prices and the best token selection for our users, so we will focus on DEXes that will bring the most benefits to them.
 
-<Warning >
-**WE DO NOT CHARGE FEES FOR INTEGRATION.**
-</Warning>
-
 ## Integration Prerequisites
 
 As Solana grows and more DEXes are built, we have to be more cautious in the DEXes we integrate, we look into a variety of factors.


### PR DESCRIPTION
## Summary
Joedoe asked us to remove the "WE DO NOT CHARGE FEES FOR INTEGRATION" callout from the Integrate DEX into Metis page for enterprise deal purposes.

## Changes
- Removed the `<Warning>` callout from `swap/routing/dex-integration.mdx`

## Linear Issues
- Fixes [DEVREL-175](https://linear.app/raccoons/issue/DEVREL-175/swap-remove-no-fees-integration-callout-from-dex-integration-page) — [Swap] Remove no-fees integration callout from dex-integration page

## Checklist
- [x] `node generate-llms-from-docs.js` run
- [x] `mint broken-links` passes
- [x] All pages have `title`, `description`, `llmsDescription`
- [ ] `docs.json` navigation updated (if applicable) — N/A
- [ ] Redirects added (if paths changed) — N/A
- [ ] Changelog entry added to `updates/index.mdx` (if API/product change) — N/A, no public API change
- [ ] `.claude/rules/` updated with any learnings or decisions — N/A
