### PR TITLE
[Trigger] Update rollout time in docs

### DIFF
--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -24,7 +24,7 @@ llmsDescription: "Changelog for Jupiter developer APIs, SDKs, and docs. Tracks b
 ## Trigger API: Upcoming Craft Deposit Request Change
 
 <Danger>
-**Action Required** - A breaking change is currently planned for Wednesday, May 13, 2026. Update Trigger V2 integrations that craft price-order deposits before enforcement.
+**Action Required** - A breaking change is planned for Thursday, May 14, 2026 at 4:00 AM UTC / 12:00 PM SGT. Update Trigger V2 integrations that craft price-order deposits before enforcement.
 </Danger>
 
 `POST https://api.jup.ag/trigger/v2/deposit/craft` will require explicit order metadata when crafting deposits for price orders:

--- a/trigger/create-order.mdx
+++ b/trigger/create-order.mdx
@@ -7,7 +7,7 @@ llmsDescription: "How to create Trigger V2 price orders using POST /trigger/v2/d
 Creating an order in V2 is a two-step process: craft and sign a deposit transaction, then submit it alongside your order parameters.
 
 <Warning>
-**Action required:** This change is currently planned for Wednesday, May 13, 2026. Price-order deposits crafted with `POST /trigger/v2/deposit/craft` must include `orderType: "price"` and `orderSubType`. Requests missing either field will return a `4xx`.
+**Action required:** This change is planned for Thursday, May 14, 2026 at 4:00 AM UTC / 12:00 PM SGT. Price-order deposits crafted with `POST /trigger/v2/deposit/craft` must include `orderType: "price"` and `orderSubType`. Requests missing either field will return a `4xx`.
 </Warning>
 
 <Tip>


### PR DESCRIPTION
## Summary
Updates the Trigger V2 breaking-change rollout date from the previous May 13 target to the confirmed Thursday, May 14, 2026 rollout time.

## Changes
- Updates the Trigger create-order warning with 4:00 AM UTC / 12:00 PM SGT.
- Updates the changelog entry with the same confirmed rollout time.

## Linear Issues
- Fixes [DEV-407](https://linear.app/raccoons/issue/DEV-407)

## Checklist
- [x] `node generate-llms-from-docs.js` run
- [ ] `mint broken-links` passes
- [x] All pages have `title`, `description`, `llmsDescription`
- [x] `docs.json` navigation updated (if applicable)
- [x] Redirects added (if paths changed)
- [x] Changelog entry added to `updates/index.mdx` (if API/product change)
- [x] `.claude/rules/` updated with any learnings or decisions

Note: `mint broken-links` currently fails on an unrelated existing image link in `blog-prep/ultra-vs-metis-rewrite.mdx`.
