### PR TITLE
fix: [banner] correct migration guide link path

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "banner": {
-    "content": "The Jupiter Developer Platform is live. Previous portal users keep their rate limits for free until **30 June 2026** — set up billing on the [**new platform**](https://developers.jup.ag/portal) before then. See the [**Migration Guide**](/portal/migration) for details."
+    "content": "The Jupiter Developer Platform is live. Previous portal users keep their rate limits for free until **30 June 2026** — set up billing on the [**new platform**](https://developers.jup.ag/portal) before then. See the [**Migration Guide**](/docs/portal/migration) for details."
   },
   "theme": "mint",
   "name": "Jupiter",


### PR DESCRIPTION
Banner link pointed to /portal/migration which 404s since all docs live under the /docs/* prefix. Updated to /docs/portal/migration.