### PR TITLE
[Swap] Clarify feeBps vs platformFee feeBps

### DIFF
--- a/.claude/rules/product-learning.md
+++ b/.claude/rules/product-learning.md
@@ -55,6 +55,7 @@ Keep entries concise — one line if possible, a short paragraph if needed.
 - [2026-04-16] Two integration paths: **Meta-Aggregator** (`/order` + `/execute`) where Jupiter handles transaction assembly and landing, and **Router** (`/build` + `/submit` or own RPC) where the integrator builds the transaction. The swap overview page uses this framing.
 - [2026-03-17] `/order` without optional params gets all routers (Metis, JupiterZ, Hashflow, Dflow, OKX, Mantis). Adding certain params (fee, slippage overrides) may restrict to Metis-only routing.
 - [2026-03-17] `/build` has no Jupiter swap fees. Only integrator platform fees via `platformFeeBps`.
+- [2026-05-15] `/order` top-level `feeBps` is the total fee rate charged for the swap. `platformFee.feeBps` is the Jupiter platform fee component and can be lower when the swap includes gasless support cost recoup.
 - [2026-03-17] `/build` returns `computeBudgetInstructions` with CU price only, NOT CU limit. Integrators must simulate to determine CU limit (confirmed from `ultra-api` source: `setComputeUnitPrice` only).
 
 ## V1 vs V2 Instruction Differences

--- a/.claude/rules/style-guide.md
+++ b/.claude/rules/style-guide.md
@@ -81,7 +81,7 @@ Technical but approachable. Professional and precise, not cold or overly formal.
 - **TypeScript is the default language** for code examples
 - If showing multiple languages, use Mintlify's `<CodeGroup>`:
 
-```mdx
+````mdx
     <CodeGroup>
     ```typescript TypeScript
     // example
@@ -90,7 +90,7 @@ Technical but approachable. Professional and precise, not cold or overly formal.
     # example
     ```
     </CodeGroup>
-```
+````
 
 ### API Endpoints
 

--- a/openapi-spec/swap/v2/swap.yaml
+++ b/openapi-spec/swap/v2/swap.yaml
@@ -82,7 +82,7 @@ components:
           type: string
         feeBps:
           type: number
-          description: Platform fee in basis points
+          description: Jupiter platform fee component in basis points. This is the fee Jupiter intends to make from the swap and does not include gasless support cost recoup.
         feeMint:
           type: string
 
@@ -326,7 +326,7 @@ paths:
                     type: string
                   feeBps:
                     type: number
-                    description: Total fees including platform fee and other fees
+                    description: Total fee rate charged for the swap in basis points. This includes the Jupiter platform fee plus any additional charges, such as gasless support cost recoup.
                   platformFee:
                     $ref: "#/components/schemas/PlatformFee"
                   signatureFeeLamports:

--- a/swap/advanced/gasless.mdx
+++ b/swap/advanced/gasless.mdx
@@ -27,7 +27,7 @@ Jupiter automatically covers all gas costs when the taker lacks SOL. No configur
 **What it covers:** all four gas types (signature fee, priority fee, ATA rent, other account rent).
 
 **How it works:**
-- Jupiter calculates the required SOL to cover gas and increases the swap fee. The taker receives less output tokens. The `feeBps` field in the response reflects this increased fee.
+- Jupiter calculates the required SOL to cover gas and increases the swap fee. The taker receives less output tokens. The top-level `feeBps` field reflects this increased total fee, while `platformFee.feeBps` only reflects the Jupiter platform fee.
 - A secondary signer (Jupiter's gas payer) is added to the transaction.
 
 **Limitations:**

--- a/swap/order-and-execute.mdx
+++ b/swap/order-and-execute.mdx
@@ -404,6 +404,12 @@ Jupiter charges a platform fee on `/order` swaps. This fee is included in the qu
 }
 ```
 
+#### Total fee vs platform fee
+
+The top-level `feeBps` field is the total fee rate charged for the swap. The `platformFee.feeBps` field is the Jupiter platform fee rate, which is the fee Jupiter intends to make from the swap.
+
+These values can differ when the swap includes additional charges, such as gasless support cost recoup. For example, if the platform fee for a swap pair is 5 bps and gasless support adds 7 bps, the response can show `feeBps: 12` and `platformFee.feeBps: 5`.
+
 #### Fee breakdown
 
 The platform fee varies by token pair:
@@ -427,7 +433,7 @@ Jupiter determines which token to collect fees in based on a priority list:
 4. **Bluechips** (large market cap tokens)
 5. **Others**
 
-Check the `feeBps` and `feeMint` fields in the `/order` response to see which token and rate apply to your swap.
+Check the `feeBps`, `platformFee.feeBps`, and `feeMint` fields in the `/order` response to see the total fee rate, Jupiter platform fee rate, and fee token for your swap.
 
 ### Referral fees
 
@@ -516,7 +522,7 @@ const response = await fetch(
 );
 ```
 
-Verify your fees are applied by checking the `feeBps` field in the response matches your `referralFee` value. If it falls back to the default platform fee, the `referralTokenAccount` for that `feeMint` is likely not initialised.
+Verify your fees are applied by checking the response fee fields. Top-level `feeBps` is the total fee rate charged for the swap, while `platformFee.feeBps` is the Jupiter platform fee rate. If the response falls back to the default platform fee, the `referralTokenAccount` for that `feeMint` is likely not initialised.
 
 <Warning>
   Adding `referralAccount` disables RFQ routing. You will only get Metis quotes. See the [routing impact matrix](#routing-impact-matrix) above.
@@ -528,10 +534,10 @@ The `/order` response includes these fee-related fields:
 
 | Field | Description |
 | --- | --- |
-| `feeBps` | Total fees including platform and other fees (basis points) |
+| `feeBps` | Total fee rate charged for the swap, including platform fee and additional charges such as gasless support cost recoup |
 | `feeMint` | Token fees are collected in |
 | `platformFee.amount` | Jupiter platform fee amount |
-| `platformFee.feeBps` | Jupiter platform fee rate |
+| `platformFee.feeBps` | Jupiter platform fee rate, excluding gasless support cost recoup |
 | `referralAccount` | Referral account used (if set) |
 
 ## Related


### PR DESCRIPTION
## Summary
Clarifies the Swap API V2 fee response fields after integrator confusion around `feeBps` and `platformFee.feeBps`. The docs now state that top-level `feeBps` is the total fee rate charged for the swap, while `platformFee.feeBps` is the Jupiter platform fee component and can differ when gasless support cost recoup is included.

## Changes
- Added a `feeBps` vs `platformFee.feeBps` explanation to Order & Execute with the 5 bps platform fee + 7 bps gasless recoup example.
- Updated the gasless docs and OpenAPI schema descriptions to use the same field distinction.
- Captured the product learning for future docs work.
- Fixed a fenced-code example in `.claude/rules/style-guide.md` so Mintlify can parse the repo during checks.

## Linear Issues
- Fixes [DEVREL-178](https://linear.app/raccoons/issue/DEVREL-178/swap-clarify-feebps-vs-platformfee-feebps) — [Swap] Clarify feeBps vs platformFee feeBps

## Checklist
- [x] `node generate-llms-from-docs.js` run
- [ ] `mint broken-links` passes
- [x] All pages have `title`, `description`, `llmsDescription`
- [x] `docs.json` navigation updated (not applicable)
- [x] Redirects added (not applicable)
- [x] Changelog entry added to `updates/index.mdx` (not applicable, docs clarification only)
- [x] `.claude/rules/` updated with learnings

## Validation
- `node generate-llms-from-docs.js` passed and regenerated 228 entries, with no `llms.txt` diff.
- `docs.json` parses as valid JSON.
- `mint broken-links` runs after the style-guide fence fix, but fails on 31 pre-existing broken links in `changelog/index.mdx`, V1 swap docs, and `trigger/v1/create-order.mdx`. None are introduced by this PR.
