### PR TITLE
[Swap] Add hidden quote-and-swap docs page

### DIFF
--- a/.claude/rules/product-learning.md
+++ b/.claude/rules/product-learning.md
@@ -59,6 +59,7 @@ Keep entries concise — one line if possible, a short paragraph if needed.
 - [2026-03-17] `/build` has no Jupiter swap fees. Only integrator platform fees via `platformFeeBps`.
 - [2026-05-15] `/order` top-level `feeBps` is the total fee rate charged for the swap. `platformFee.feeBps` is the Jupiter platform fee component and can be lower when the swap includes gasless support cost recoup.
 - [2026-03-17] `/build` returns `computeBudgetInstructions` with CU price only, NOT CU limit. Integrators must simulate to determine CU limit (confirmed from `ultra-api` source: `setComputeUnitPrice` only).
+- [2026-05-21] Third (hidden) integration path: `/swap/v2/quote` + `/swap/v2/swap` (or `/swap/v2/swap-instructions`). Separated quote and swap flow exposed in `jup-ag/swap-api` for integrators that need to inspect or transform the quote between routing and transaction assembly. `/quote` returns a `QuoteResponse` (Metis-only routing) that is roundtripped unchanged to `/swap` (returns base64 VersionedTransaction) or `/swap-instructions` (returns raw instructions + `addressesByLookupTableAddress`). Body for `/swap` and `/swap-instructions` is shared (`swapBodySchema`). `QuoteResponsePassthrough` uses `.passthrough()` on the server; clients must preserve unknown fields when forwarding. Documented as a hidden page at `swap/quote-and-swap.mdx`. Not in `docs.json` nav.
 
 ## Rent / Close-Account Handling (vs Ultra V1)
 

--- a/swap/quote-and-swap.mdx
+++ b/swap/quote-and-swap.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Quote and Swap"
 description: "Separated quote and swap flow for integrators that need to roundtrip a quote"
-llmsDescription: "Two-step Swap API flow at api.jup.ag/swap/v2: GET /swap/v2/quote returns a QuoteResponse, POST /swap/v2/swap returns a base64 unsigned VersionedTransaction built from that quote, POST /swap/v2/swap-instructions returns raw instructions plus address lookup tables built from that quote. All three require an x-api-key header and are served only on api.jup.ag (not on lite-api.jup.ag). The compute-unit limit is pinned at 1,400,000 with no per-route simulation. The wSOL token account is closed when wrapAndUnwrapSol=true with rent returned to the taker, not the payer (different from /order). tipAmount transfers SOL to a randomly chosen receiver from a fixed allowlist of 16 Jupiter V6 program authorities. Includes runnable TypeScript examples in both @solana/kit and @solana/web3.js for the quote-then-swap flow."
+llmsDescription: "Two-step Swap API flow at api.jup.ag/swap/v2: GET /swap/v2/quote returns a QuoteResponse, POST /swap/v2/swap returns a base64 unsigned VersionedTransaction built from that quote, POST /swap/v2/swap-instructions returns raw instructions plus address lookup tables built from that quote. All three require an x-api-key header and are served only on api.jup.ag (not on lite-api.jup.ag). The compute-unit limit is pinned at 1,400,000 with no per-route simulation. The wSOL token account is closed when wrapAndUnwrapSol=true with rent returned to the taker, not the payer (different from /order). tipAmount transfers SOL to a randomly chosen receiver from a fixed allowlist of Jupiter authorities. Includes runnable TypeScript examples in both @solana/kit and @solana/web3.js for the quote-then-swap flow."
 hidden: true
 ---
 
@@ -96,7 +96,7 @@ POST https://api.jup.ag/swap/v2/swap-instructions
 | `nativeDestinationAccount`   | `string`                                                          | No       | Native SOL account that receives the output. Mutually exclusive with `destinationTokenAccount`                    |
 | `wrapAndUnwrapSol`           | `boolean`                                                         | No       | Wrap/unwrap SOL automatically. Defaults to `true`. Always closes the wSOL token account after the swap            |
 | `blockhashSlotsToExpiry`     | `number`                                                          | No       | Slots until the blockhash expires (1–300). Defaults to `150`                                                      |
-| `tipAmount`                  | `string`                                                          | No       | Lamports to transfer to a permitted tip receiver via an included tip instruction. **Minimum is `1000000` lamports (0.001 SOL).** The receiver is randomly selected per request from a fixed set of 16 Jupiter V6 program authority addresses (see [Tip receivers](#tip-receivers)). Paid by `payer` (or `taker`) |
+| `tipAmount`                  | `string`                                                          | No       | Lamports to transfer to a permitted tip receiver via an included tip instruction. **Minimum is `1000000` lamports (0.001 SOL).** The receiver is randomly selected per request from a fixed set of Jupiter authority addresses (see [Tip receivers](#tip-receivers)). Paid by `payer` (or `taker`) |
 | `computeUnitPricePercentile` | `"medium"` &#124; `"high"` &#124; `"veryHigh"` &#124; `number`    | No       | Named level or integer (0–10000 bps) that controls the `setComputeUnitPrice` instruction. Named levels map to `"medium"`=2500, `"high"`=5000, `"veryHigh"`=7500. Defaults to **5000 bps (50th percentile)** when omitted |
 
 ### /swap response
@@ -152,7 +152,7 @@ Both endpoints return JSON of the form `{ "error": "<message>" }`. Status codes:
 
 ### Tip receivers
 
-The tip recipient is randomly selected per request from a fixed 16-address allowlist of Jupiter V6 program authorities. You cannot choose the receiver. Multiple recipients exist to spread writable-account contention during landing. Same allowlist as [`/submit`](/transaction/submit).
+The tip recipient is randomly selected per request from a fixed allowlist of Jupiter authorities. You cannot choose the receiver. Multiple recipients exist to spread writable-account contention during landing. Same allowlist as [`/submit`](/transaction/submit).
 
 ## Quote then swap
 

--- a/swap/quote-and-swap.mdx
+++ b/swap/quote-and-swap.mdx
@@ -1,0 +1,190 @@
+---
+title: "Quote and Swap"
+description: "Separated quote and swap flow for integrators that need to roundtrip a quote"
+llmsDescription: "How to use the separated quote and swap flow on Jupiter Swap API V2 via three endpoints: GET https://api.jup.ag/swap/v2/quote returns a QuoteResponse; POST https://api.jup.ag/swap/v2/swap takes that QuoteResponse and returns a base64-encoded unsigned VersionedTransaction; POST https://api.jup.ag/swap/v2/swap-instructions takes the same QuoteResponse and returns raw Solana instructions plus address lookup table data. Useful when an integrator needs to inspect, log, or transform the quote between routing and transaction assembly. Parameters: inputMint, outputMint, amount, slippageBps, dexes/excludeDexes, platformFeeBps, dynamicSwap on /quote; taker, payer, feeAccount, destinationTokenAccount, nativeDestinationAccount, wrapAndUnwrapSol, blockhashSlotsToExpiry, tipAmount, computeUnitPricePercentile on /swap and /swap-instructions. Includes a complete TypeScript example for the quote then swap flow."
+hidden: true
+---
+
+The Swap API exposes a separated quote and swap flow under `/swap/v2`. Get a quote in one call, then pass that quote into a second call to either receive a fully built transaction or raw instructions.
+
+Use this flow when you need to inspect, log, or transform the quote between routing and transaction assembly. If you do not need that separation, use [Order & Execute](/swap/order-and-execute) (managed) or [Build](/swap/build) (instructions in a single call) instead.
+
+## Endpoints
+
+| Endpoint                          | Purpose                                                              |
+|-----------------------------------|----------------------------------------------------------------------|
+| `GET /swap/v2/quote`              | Returns a `QuoteResponse` describing the best route                  |
+| `POST /swap/v2/swap`              | Builds a base64-encoded unsigned VersionedTransaction from a quote   |
+| `POST /swap/v2/swap-instructions` | Returns raw Solana instructions and ALT data from a quote            |
+
+The `QuoteResponse` returned by `/quote` must be passed back **unchanged** to `/swap` or `/swap-instructions`. The response contains fields that are not part of the documented schema but are required for transaction assembly. Preserve unknown fields using a passthrough type (`Record<string, unknown>`, `serde_json::Value`, or similar). Do not deserialise into a strict struct and re-serialise.
+
+## GET /swap/v2/quote
+
+```
+GET https://api.jup.ag/swap/v2/quote
+```
+
+### Query parameters
+
+| Parameter                       | Type      | Required | Description                                                                                                                |
+|---------------------------------|-----------|----------|----------------------------------------------------------------------------------------------------------------------------|
+| `inputMint`                     | `string`  | Yes      | Mint address of the input token                                                                                            |
+| `outputMint`                    | `string`  | Yes      | Mint address of the output token                                                                                           |
+| `amount`                        | `string`  | Yes      | Amount of `inputMint` to swap, in the smallest unit (e.g. lamports for SOL)                                                |
+| `slippageBps`                   | `number`  | No       | Slippage tolerance in basis points (0–10000). Baked into the response's `otherAmountThreshold`. Defaults to `50`           |
+| `dexes`                         | `string`  | No       | Comma-separated DEX identifiers to restrict routing to. Mutually exclusive with `excludeDexes`                              |
+| `excludeDexes`                  | `string`  | No       | Comma-separated DEX identifiers to exclude from routing. Mutually exclusive with `dexes`                                   |
+| `platformFeeBps`                | `number`  | No       | Platform fee in basis points (0–10000). The matching `feeAccount` must be supplied at swap time                            |
+| `useIncurredSlippageForQuoting` | `boolean` | No       | Whether to use incurred slippage for quoting. Defaults to `false`                                                          |
+| `dynamicSwap`                   | `boolean` | No       | Allow split routing across multiple candidate AMMs. Defaults to `true`. Pass `false` to opt out                            |
+
+### Response
+
+A `QuoteResponse` object. The documented fields are below; additional fields are present and **must be preserved** when forwarding the quote to `/swap` or `/swap-instructions`.
+
+| Field                  | Type      | Description                                                                  |
+|------------------------|-----------|------------------------------------------------------------------------------|
+| `inputMint`            | `string`  | Echo of the request                                                          |
+| `outputMint`           | `string`  | Echo of the request                                                          |
+| `inAmount`             | `string`  | Input amount in smallest units                                               |
+| `outAmount`            | `string`  | Expected output amount in smallest units                                     |
+| `otherAmountThreshold` | `string`  | Minimum output after applying `slippageBps`                                  |
+| `swapMode`             | `string`  | `ExactIn` or `ExactOut`                                                      |
+| `slippageBps`          | `number`  | Slippage applied to the quote                                                |
+| `priceImpactPct`       | `string`  | Price impact as a decimal string                                             |
+| `contextSlot`          | `number`  | Solana slot the route was computed against                                   |
+| `timeTaken`            | `number`  | Routing latency in seconds                                                   |
+| `routePlan`            | `array`   | Per-step route information                                                   |
+| `platformFee`          | `object`  | `{ amount, feeBps }`. Present only when `platformFeeBps` was set on `/quote` |
+
+### Errors
+
+`/quote` returns `400` for: invalid `inputMint` or `outputMint`, `inputMint === outputMint`, invalid or out-of-range `amount`, both `dexes` and `excludeDexes` set, insufficient liquidity, and token-not-tradable.
+
+## POST /swap/v2/swap and POST /swap/v2/swap-instructions
+
+Both endpoints accept the same body. They differ only in the response:
+
+- `/swap` returns a fully built, base64-encoded unsigned VersionedTransaction.
+- `/swap-instructions` returns raw instructions and address lookup table data so you can compose your own transaction.
+
+```
+POST https://api.jup.ag/swap/v2/swap
+POST https://api.jup.ag/swap/v2/swap-instructions
+```
+
+### Request body
+
+| Field                        | Type                                                              | Required | Description                                                                                                       |
+|------------------------------|-------------------------------------------------------------------|----------|-------------------------------------------------------------------------------------------------------------------|
+| `quoteResponse`              | `object`                                                          | Yes      | The full `QuoteResponse` returned by `/quote`, passed through unchanged                                            |
+| `taker`                      | `string`                                                          | Yes      | Pubkey of the wallet initiating the swap                                                                          |
+| `payer`                      | `string`                                                          | No       | Account that pays transaction fees and rent. Defaults to `taker`                                                  |
+| `feeAccount`                 | `string`                                                          | No       | Token account that collects the platform fee. Required if `quoteResponse.platformFee` is set                      |
+| `destinationTokenAccount`    | `string`                                                          | No       | SPL token account that receives the output. Mutually exclusive with `nativeDestinationAccount`                    |
+| `nativeDestinationAccount`   | `string`                                                          | No       | Native SOL account that receives the output. Mutually exclusive with `destinationTokenAccount`                    |
+| `wrapAndUnwrapSol`           | `boolean`                                                         | No       | Wrap/unwrap SOL automatically. Defaults to `true`. Always closes the wSOL token account after the swap            |
+| `blockhashSlotsToExpiry`     | `number`                                                          | No       | Slots until the blockhash expires (1–300). Defaults to `150`                                                      |
+| `tipAmount`                  | `string`                                                          | No       | Lamports to transfer to a permitted tip receiver via an included tip instruction. Paid by `payer` (or `taker`)    |
+| `computeUnitPricePercentile` | `"medium"` &#124; `"high"` &#124; `"veryHigh"` &#124; `number`    | No       | Named level or integer (0–10000 bps) that controls the compute-unit price. Defaults to a server-side percentile   |
+
+### /swap response
+
+| Field                       | Type     | Description                                                            |
+|-----------------------------|----------|------------------------------------------------------------------------|
+| `swapTransaction`           | `string` | Base64-encoded serialised unsigned `VersionedTransaction` (v0)         |
+| `lastValidBlockHeight`      | `number` | Last block height at which the included blockhash is valid             |
+| `prioritizationFeeLamports` | `number` | Compute-unit price multiplied by the default compute-unit limit        |
+| `computeUnitPrice`          | `string` | Resolved compute-unit price, in micro-lamports                         |
+
+### /swap-instructions response
+
+| Field                              | Type                      | Description                                                                                                       |
+|------------------------------------|---------------------------|-------------------------------------------------------------------------------------------------------------------|
+| `computeBudgetInstructions`        | `Instruction[]`           | Compute budget instructions (sets the compute-unit price)                                                         |
+| `setupInstructions`                | `Instruction[]`           | Setup (e.g. create-ATA, wrap-SOL) that must precede the swap                                                      |
+| `swapInstruction`                  | `Instruction`             | The swap instruction itself                                                                                       |
+| `cleanupInstruction`               | `Instruction \| null`     | Cleanup (e.g. unwrap-SOL) that must follow the swap                                                                |
+| `otherInstructions`                | `Instruction[]`           | Additional instructions required by the route                                                                     |
+| `tipInstruction`                   | `Instruction \| null`     | Present when `tipAmount` was supplied                                                                             |
+| `addressesByLookupTableAddress`    | `Record<string, string[]>`| Address Lookup Tables required to compile the v0 transaction (table address → contained addresses)                 |
+| `blockhashWithMetadata.blockhash`  | `number[]`                | Recent blockhash as a byte array                                                                                  |
+| `blockhashWithMetadata.lastValidBlockHeight` | `number`        | Last block height at which the blockhash is valid                                                                 |
+
+`Instruction` has the shape `{ programId: string, accounts: { pubkey: string, isWritable: boolean, isSigner: boolean }[], data: string }`. `data` is base64-encoded.
+
+The `addressesByLookupTableAddress` mapping contains every ALT needed to compile the transaction. **Do not fetch ALTs from RPC.** Build `AddressLookupTableAccount` instances directly from this response.
+
+## Quote then swap
+
+```typescript
+import { Connection, VersionedTransaction } from "@solana/web3.js";
+
+const BASE_URL = "https://api.jup.ag/swap/v2";
+const taker = wallet.publicKey.toBase58();
+
+// 1. Quote
+const quoteUrl = `${BASE_URL}/quote?` + new URLSearchParams({
+  inputMint: "So11111111111111111111111111111111111111112",
+  outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  amount: "1000000000",
+  slippageBps: "50",
+});
+
+const quoteRes = await fetch(quoteUrl);
+if (!quoteRes.ok) {
+  throw new Error(`quote failed: ${await quoteRes.text()}`);
+}
+const quoteResponse = await quoteRes.json();
+
+// 2. Build the transaction (pass quoteResponse through unchanged)
+const swapRes = await fetch(`${BASE_URL}/swap`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    quoteResponse,
+    taker,
+  }),
+});
+if (!swapRes.ok) {
+  throw new Error(`swap failed: ${await swapRes.text()}`);
+}
+const { swapTransaction, lastValidBlockHeight } = await swapRes.json();
+
+// 3. Deserialise, sign, and send
+const tx = VersionedTransaction.deserialize(Buffer.from(swapTransaction, "base64"));
+const signed = await wallet.signTransaction(tx);
+
+const connection = new Connection("https://api.mainnet-beta.solana.com");
+const signature = await connection.sendRawTransaction(signed.serialize(), {
+  skipPreflight: true,
+});
+
+await connection.confirmTransaction(
+  {
+    signature,
+    blockhash: tx.message.recentBlockhash,
+    lastValidBlockHeight,
+  },
+  "confirmed"
+);
+```
+
+## Quote then swap-instructions
+
+When you need to compose your own transaction (custom fee payer, CPI, batching, etc.), call `/swap-instructions` instead. Convert the returned objects into `TransactionInstruction` and build `AddressLookupTableAccount` instances from `addressesByLookupTableAddress`. The transaction is v0 and must include the compute budget, setup, swap, cleanup, and any `otherInstructions` in that order.
+
+## Notes
+
+- **Preserve the full `quoteResponse`.** The schema is `passthrough` on the server side. Strict-typed clients that drop unknown fields will get `500 Internal Server Error` from `/swap` and `/swap-instructions`. Forward the JSON as-is.
+- **`platformFeeBps` requires `feeAccount`.** If you request a platform fee on `/quote`, you must supply the matching `feeAccount` on the swap call.
+- **wSOL token account is always closed** when `wrapAndUnwrapSol=true`, regardless of whether SOL is the input or output mint. The rent is returned to `payer` (or `taker` if `payer` is not specified).
+- **`dexes` and `excludeDexes` are mutually exclusive.** Sending both returns `400`.
+- **No `/execute` for this flow.** `/execute` is exclusive to `/order`. To submit transactions built via `/swap`, use your own RPC or [`/submit`](/transaction/submit).
+
+## Related
+
+- [Order & Execute](/swap/order-and-execute): the managed swap flow (`/order` + `/execute`)
+- [Build](/swap/build): raw instructions in a single call, no separate quote step
+- [`/submit`](/transaction/submit): Jupiter transaction landing endpoint

--- a/swap/quote-and-swap.mdx
+++ b/swap/quote-and-swap.mdx
@@ -1,13 +1,23 @@
 ---
 title: "Quote and Swap"
 description: "Separated quote and swap flow for integrators that need to roundtrip a quote"
-llmsDescription: "How to use the separated quote and swap flow on Jupiter Swap API V2 via three endpoints: GET https://api.jup.ag/swap/v2/quote returns a QuoteResponse; POST https://api.jup.ag/swap/v2/swap takes that QuoteResponse and returns a base64-encoded unsigned VersionedTransaction; POST https://api.jup.ag/swap/v2/swap-instructions takes the same QuoteResponse and returns raw Solana instructions plus address lookup table data. Useful when an integrator needs to inspect, log, or transform the quote between routing and transaction assembly. Parameters: inputMint, outputMint, amount, slippageBps, dexes/excludeDexes, platformFeeBps, dynamicSwap on /quote; taker, payer, feeAccount, destinationTokenAccount, nativeDestinationAccount, wrapAndUnwrapSol, blockhashSlotsToExpiry, tipAmount, computeUnitPricePercentile on /swap and /swap-instructions. Includes a complete TypeScript example for the quote then swap flow."
+llmsDescription: "Two-step Swap API flow at api.jup.ag/swap/v2: GET /swap/v2/quote returns a QuoteResponse, POST /swap/v2/swap returns a base64 unsigned VersionedTransaction built from that quote, POST /swap/v2/swap-instructions returns raw instructions plus address lookup tables built from that quote. All three require an x-api-key header and are served only on api.jup.ag (not on lite-api.jup.ag). The compute-unit limit is pinned at 1,400,000 with no per-route simulation. The wSOL token account is closed when wrapAndUnwrapSol=true with rent returned to the taker, not the payer (different from /order). tipAmount transfers SOL to a randomly chosen receiver from a fixed allowlist of 16 Jupiter V6 program authorities. Includes runnable TypeScript examples in both @solana/kit and @solana/web3.js for the quote-then-swap flow."
 hidden: true
 ---
 
-The Swap API exposes a separated quote and swap flow under `/swap/v2`. Get a quote in one call, then pass that quote into a second call to either receive a fully built transaction or raw instructions.
+Two-step swap flow under `/swap/v2`. `/quote` returns a route; `/swap` builds the transaction from that route, or `/swap-instructions` returns raw instructions for you to assemble yourself.
 
-Use this flow when you need to inspect, log, or transform the quote between routing and transaction assembly. If you do not need that separation, use [Order & Execute](/swap/order-and-execute) (managed) or [Build](/swap/build) (instructions in a single call) instead.
+Use this when you need the quote and build steps as separate calls, typically to inspect, log, or branch on the quote before transaction assembly. If you do not, prefer [Order & Execute](/swap/order-and-execute) (managed end-to-end) or [Build](/swap/build) (instructions in one call).
+
+## Authentication
+
+All three endpoints require an API key passed via the `x-api-key` header. Get one at [Portal](https://developers.jup.ag/portal).
+
+```bash
+curl -H "x-api-key: $JUPITER_API_KEY" "https://api.jup.ag/swap/v2/quote?..."
+```
+
+These endpoints are served only on `api.jup.ag`. The `lite-api.jup.ag` host returns `404` for `/swap/v2/{quote,swap,swap-instructions}`.
 
 ## Endpoints
 
@@ -36,7 +46,7 @@ GET https://api.jup.ag/swap/v2/quote
 | `dexes`                         | `string`  | No       | Comma-separated DEX identifiers to restrict routing to. Mutually exclusive with `excludeDexes`                              |
 | `excludeDexes`                  | `string`  | No       | Comma-separated DEX identifiers to exclude from routing. Mutually exclusive with `dexes`                                   |
 | `platformFeeBps`                | `number`  | No       | Platform fee in basis points (0–10000). The matching `feeAccount` must be supplied at swap time                            |
-| `useIncurredSlippageForQuoting` | `boolean` | No       | Whether to use incurred slippage for quoting. Defaults to `false`                                                          |
+| `useIncurredSlippageForQuoting` | `boolean` | No       | Enables Metis's incurred-slippage adjustment. Internal data shows ~0.4–0.8 bps better quotes when enabled. Defaults to `false`; pass `true` to opt in |
 | `dynamicSwap`                   | `boolean` | No       | Allow split routing across multiple candidate AMMs. Defaults to `true`. Pass `false` to opt out                            |
 
 ### Response
@@ -86,8 +96,8 @@ POST https://api.jup.ag/swap/v2/swap-instructions
 | `nativeDestinationAccount`   | `string`                                                          | No       | Native SOL account that receives the output. Mutually exclusive with `destinationTokenAccount`                    |
 | `wrapAndUnwrapSol`           | `boolean`                                                         | No       | Wrap/unwrap SOL automatically. Defaults to `true`. Always closes the wSOL token account after the swap            |
 | `blockhashSlotsToExpiry`     | `number`                                                          | No       | Slots until the blockhash expires (1–300). Defaults to `150`                                                      |
-| `tipAmount`                  | `string`                                                          | No       | Lamports to transfer to a permitted tip receiver via an included tip instruction. Paid by `payer` (or `taker`)    |
-| `computeUnitPricePercentile` | `"medium"` &#124; `"high"` &#124; `"veryHigh"` &#124; `number`    | No       | Named level or integer (0–10000 bps) that controls the compute-unit price. Defaults to a server-side percentile   |
+| `tipAmount`                  | `string`                                                          | No       | Lamports to transfer to a permitted tip receiver via an included tip instruction. **Minimum is `1000000` lamports (0.001 SOL).** The receiver is randomly selected per request from a fixed set of 16 Jupiter V6 program authority addresses (see [Tip receivers](#tip-receivers)). Paid by `payer` (or `taker`) |
+| `computeUnitPricePercentile` | `"medium"` &#124; `"high"` &#124; `"veryHigh"` &#124; `number`    | No       | Named level or integer (0–10000 bps) that controls the `setComputeUnitPrice` instruction. Named levels map to `"medium"`=2500, `"high"`=5000, `"veryHigh"`=7500. Defaults to **5000 bps (50th percentile)** when omitted |
 
 ### /swap response
 
@@ -95,19 +105,19 @@ POST https://api.jup.ag/swap/v2/swap-instructions
 |-----------------------------|----------|------------------------------------------------------------------------|
 | `swapTransaction`           | `string` | Base64-encoded serialised unsigned `VersionedTransaction` (v0)         |
 | `lastValidBlockHeight`      | `number` | Last block height at which the included blockhash is valid             |
-| `prioritizationFeeLamports` | `number` | Compute-unit price multiplied by the default compute-unit limit        |
+| `prioritizationFeeLamports` | `number` | Compute-unit price multiplied by the pinned compute-unit limit of 1,400,000 (see the [Compute unit limit](#compute-unit-limit) note) |
 | `computeUnitPrice`          | `string` | Resolved compute-unit price, in micro-lamports                         |
 
 ### /swap-instructions response
 
 | Field                              | Type                      | Description                                                                                                       |
 |------------------------------------|---------------------------|-------------------------------------------------------------------------------------------------------------------|
-| `computeBudgetInstructions`        | `Instruction[]`           | Compute budget instructions (sets the compute-unit price)                                                         |
+| `computeBudgetInstructions`        | `Instruction[]`           | Includes `SetComputeUnitLimit(1_400_000)` and `SetComputeUnitPrice(...)`. See the [Compute unit limit](#compute-unit-limit) note          |
 | `setupInstructions`                | `Instruction[]`           | Setup (e.g. create-ATA, wrap-SOL) that must precede the swap                                                      |
 | `swapInstruction`                  | `Instruction`             | The swap instruction itself                                                                                       |
 | `cleanupInstruction`               | `Instruction \| null`     | Cleanup (e.g. unwrap-SOL) that must follow the swap                                                                |
 | `otherInstructions`                | `Instruction[]`           | Additional instructions required by the route                                                                     |
-| `tipInstruction`                   | `Instruction \| null`     | Present when `tipAmount` was supplied                                                                             |
+| `tipInstruction`                   | `Instruction \| null`     | Present when `tipAmount` was supplied. Transfers SOL from `payer` (or `taker`) to a randomly chosen receiver from the [Tip receivers](#tip-receivers) allowlist |
 | `addressesByLookupTableAddress`    | `Record<string, string[]>`| Address Lookup Tables required to compile the v0 transaction (table address → contained addresses)                 |
 | `blockhashWithMetadata.blockhash`  | `number[]`                | Recent blockhash as a byte array                                                                                  |
 | `blockhashWithMetadata.lastValidBlockHeight` | `number`        | Last block height at which the blockhash is valid                                                                 |
@@ -116,13 +126,58 @@ POST https://api.jup.ag/swap/v2/swap-instructions
 
 The `addressesByLookupTableAddress` mapping contains every ALT needed to compile the transaction. **Do not fetch ALTs from RPC.** Build `AddressLookupTableAccount` instances directly from this response.
 
+### Compute unit limit
+
+<Note>
+**CUL pinned at 1,400,000.** `/swap` and `/swap-instructions` always emit `setComputeUnitLimit(1_400_000)` with no per-route simulation. The transaction pays priority fee for the full 1.4M regardless of actual CU consumption. Routes that consume fewer CUs overpay relative to a simulated tight-CU build.
+
+Per-route CU sizing is possible at ~30–100ms additional routing latency. Contact the swap team if you need it.
+</Note>
+
+### Errors
+
+Both endpoints return JSON of the form `{ "error": "<message>" }`. Status codes:
+
+| Status | Trigger                                                                                                |
+|--------|--------------------------------------------------------------------------------------------------------|
+| `400`  | Invalid `taker` address                                                                                |
+| `400`  | Invalid `payer` address                                                                                |
+| `400`  | `quoteResponse.platformFee` is set but `feeAccount` is missing                                         |
+| `400`  | Invalid `feeAccount` address                                                                           |
+| `400`  | Both `destinationTokenAccount` and `nativeDestinationAccount` provided (mutually exclusive)            |
+| `400`  | Invalid destination account address                                                                    |
+| `400`  | Invalid `tipAmount`: must parse as a positive integer ≥ `1000000` lamports (0.001 SOL minimum)           |
+| `400`  | Metis returned a routing error (e.g. `"Quote not available from market maker"`, insufficient liquidity)|
+| `400`  | Unexpected exception while contacting Metis                                                            |
+
+### Tip receivers
+
+The tip recipient is randomly selected per request from a fixed 16-address allowlist of Jupiter V6 program authorities. You cannot choose the receiver. Multiple recipients exist to spread writable-account contention during landing. Same allowlist as [`/submit`](/transaction/submit).
+
 ## Quote then swap
 
-```typescript
-import { Connection, VersionedTransaction } from "@solana/web3.js";
+<CodeGroup>
+```typescript title="@solana/kit"
+import {
+  createKeyPairSignerFromBytes,
+  createSolanaRpc,
+  getBase58Encoder,
+  getBase64Codec,
+  getBase64EncodedWireTransaction,
+  getTransactionDecoder,
+  partiallySignTransaction,
+} from "@solana/kit";
 
+const API_KEY = process.env.JUPITER_API_KEY;
+const RPC_URL = process.env.RPC_URL;
+if (!API_KEY) throw new Error("Missing JUPITER_API_KEY");
+if (!RPC_URL) throw new Error("Missing RPC_URL");
+
+const signer = await createKeyPairSignerFromBytes(
+  getBase58Encoder().encode(process.env.BS58_PRIVATE_KEY!),
+);
+const rpc = createSolanaRpc(RPC_URL);
 const BASE_URL = "https://api.jup.ag/swap/v2";
-const taker = wallet.publicKey.toBase58();
 
 // 1. Quote
 const quoteUrl = `${BASE_URL}/quote?` + new URLSearchParams({
@@ -131,57 +186,92 @@ const quoteUrl = `${BASE_URL}/quote?` + new URLSearchParams({
   amount: "1000000000",
   slippageBps: "50",
 });
-
-const quoteRes = await fetch(quoteUrl);
-if (!quoteRes.ok) {
-  throw new Error(`quote failed: ${await quoteRes.text()}`);
-}
+const quoteRes = await fetch(quoteUrl, { headers: { "x-api-key": API_KEY } });
+if (!quoteRes.ok) throw new Error(`quote failed: ${await quoteRes.text()}`);
 const quoteResponse = await quoteRes.json();
 
 // 2. Build the transaction (pass quoteResponse through unchanged)
 const swapRes = await fetch(`${BASE_URL}/swap`, {
   method: "POST",
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({
-    quoteResponse,
-    taker,
-  }),
+  headers: { "Content-Type": "application/json", "x-api-key": API_KEY },
+  body: JSON.stringify({ quoteResponse, taker: signer.address }),
 });
-if (!swapRes.ok) {
-  throw new Error(`swap failed: ${await swapRes.text()}`);
-}
-const { swapTransaction, lastValidBlockHeight } = await swapRes.json();
+if (!swapRes.ok) throw new Error(`swap failed: ${await swapRes.text()}`);
+const { swapTransaction } = await swapRes.json();
 
-// 3. Deserialise, sign, and send
+// 3. Decode, sign, send
+const txBytes = Uint8Array.from(getBase64Codec().encode(swapTransaction));
+const signed = await partiallySignTransaction(
+  [signer.keyPair],
+  getTransactionDecoder().decode(txBytes),
+);
+const signature = await rpc
+  .sendTransaction(getBase64EncodedWireTransaction(signed), {
+    encoding: "base64",
+    skipPreflight: true,
+  })
+  .send();
+
+console.log(`https://solscan.io/tx/${signature}`);
+```
+
+```typescript title="@solana/web3.js"
+import { Connection, Keypair, VersionedTransaction } from "@solana/web3.js";
+import bs58 from "bs58";
+
+const API_KEY = process.env.JUPITER_API_KEY;
+const RPC_URL = process.env.RPC_URL;
+if (!API_KEY) throw new Error("Missing JUPITER_API_KEY");
+if (!RPC_URL) throw new Error("Missing RPC_URL");
+
+const signer = Keypair.fromSecretKey(bs58.decode(process.env.BS58_PRIVATE_KEY!));
+const connection = new Connection(RPC_URL);
+const BASE_URL = "https://api.jup.ag/swap/v2";
+
+// 1. Quote
+const quoteUrl = `${BASE_URL}/quote?` + new URLSearchParams({
+  inputMint: "So11111111111111111111111111111111111111112",
+  outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  amount: "1000000000",
+  slippageBps: "50",
+});
+const quoteRes = await fetch(quoteUrl, { headers: { "x-api-key": API_KEY } });
+if (!quoteRes.ok) throw new Error(`quote failed: ${await quoteRes.text()}`);
+const quoteResponse = await quoteRes.json();
+
+// 2. Build the transaction (pass quoteResponse through unchanged)
+const swapRes = await fetch(`${BASE_URL}/swap`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json", "x-api-key": API_KEY },
+  body: JSON.stringify({ quoteResponse, taker: signer.publicKey.toBase58() }),
+});
+if (!swapRes.ok) throw new Error(`swap failed: ${await swapRes.text()}`);
+const { swapTransaction } = await swapRes.json();
+
+// 3. Decode, sign, send
 const tx = VersionedTransaction.deserialize(Buffer.from(swapTransaction, "base64"));
-const signed = await wallet.signTransaction(tx);
-
-const connection = new Connection("https://api.mainnet-beta.solana.com");
-const signature = await connection.sendRawTransaction(signed.serialize(), {
+tx.sign([signer]);
+const signature = await connection.sendRawTransaction(tx.serialize(), {
   skipPreflight: true,
 });
 
-await connection.confirmTransaction(
-  {
-    signature,
-    blockhash: tx.message.recentBlockhash,
-    lastValidBlockHeight,
-  },
-  "confirmed"
-);
+console.log(`https://solscan.io/tx/${signature}`);
 ```
+</CodeGroup>
+
+The `/swap` response also returns `lastValidBlockHeight`, `prioritizationFeeLamports`, and `computeUnitPrice` (see the response table above). Confirm the landed signature against `lastValidBlockHeight` using your usual confirmation logic, or hand the signed transaction to [`/submit`](/transaction/submit) instead of `sendTransaction` for Jupiter's managed landing pipeline.
 
 ## Quote then swap-instructions
 
-When you need to compose your own transaction (custom fee payer, CPI, batching, etc.), call `/swap-instructions` instead. Convert the returned objects into `TransactionInstruction` and build `AddressLookupTableAccount` instances from `addressesByLookupTableAddress`. The transaction is v0 and must include the compute budget, setup, swap, cleanup, and any `otherInstructions` in that order.
+Call `/swap-instructions` instead when you need to assemble the transaction yourself (custom fee payer, CPI, batching). Convert each returned object into `TransactionInstruction`, build `AddressLookupTableAccount`s from `addressesByLookupTableAddress`, and assemble in order: `computeBudgetInstructions`, `setupInstructions`, `swapInstruction`, `cleanupInstruction`, `otherInstructions`.
 
-## Notes
+## Gotchas
 
-- **Preserve the full `quoteResponse`.** The schema is `passthrough` on the server side. Strict-typed clients that drop unknown fields will get `500 Internal Server Error` from `/swap` and `/swap-instructions`. Forward the JSON as-is.
-- **`platformFeeBps` requires `feeAccount`.** If you request a platform fee on `/quote`, you must supply the matching `feeAccount` on the swap call.
-- **wSOL token account is always closed** when `wrapAndUnwrapSol=true`, regardless of whether SOL is the input or output mint. The rent is returned to `payer` (or `taker` if `payer` is not specified).
+- **Preserve `quoteResponse` verbatim.** The server uses `.passthrough()`; strict-typed clients that drop unknown fields will get `500` from `/swap` and `/swap-instructions`. Forward the JSON as received.
+- **`platformFeeBps` requires `feeAccount`.** If `/quote` is called with `platformFeeBps`, the swap call must include the matching `feeAccount`. Otherwise the server rejects with `400`.
+- **wSOL rent goes to `taker`, not `payer`.** When `wrapAndUnwrapSol=true`, `cleanupInstruction` is a plain `CloseAccount` whose rent destination is the wSOL TA owner: the `taker`. No compensating SOL transfer is appended. This matches `/build`; `/order` is the only path that compensates `payer`. Add your own transfer if you need the rent elsewhere.
 - **`dexes` and `excludeDexes` are mutually exclusive.** Sending both returns `400`.
-- **No `/execute` for this flow.** `/execute` is exclusive to `/order`. To submit transactions built via `/swap`, use your own RPC or [`/submit`](/transaction/submit).
+- **No `/execute` for this flow.** `/execute` is `/order`-only. It validates a cached transaction by `requestId`, which this flow does not return. Submit via your own RPC or [`/submit`](/transaction/submit).
 
 ## Related
 


### PR DESCRIPTION
## Summary

Adds a hidden Mintlify page documenting a separated quote/swap flow on Swap API V2 (`/swap/v2/quote`, `/swap/v2/swap`, `/swap/v2/swap-instructions`). These endpoints wrap Metis with a quote-then-build pattern for integrators that need the steps as separate calls. The page is hidden (`hidden: true`, not in `docs.json` nav) so it stays unlisted but reachable by URL.

## Changes

- New `swap/quote-and-swap.mdx` covering all three endpoints: parameter tables, response shapes, an errors table for `/swap` and `/swap-instructions`, a Compute Unit Limit note (CUL is pinned at 1,400,000), a Tip Receivers note (random selection from the same 16-address allowlist as `/submit`), a Gotchas section, and runnable TypeScript examples in `@solana/kit` and `@solana/web3.js` (kit first per the 2026-03-17 dual-SDK convention).
- All schemas, defaults, error paths, the wSOL rent destination claim (rent → `taker`, matches `/build`, not `/order`), the tip recipient allowlist, and the CUL pin behaviour were verified empirically against the live API.
- `.claude/rules/product-learning.md` updated with the new flow under Swap V2 Architecture.

## Linear Issues

- Fixes [DEV-428](https://linear.app/raccoons/issue/DEV-428/swap-add-hidden-docs-page-for-quote-swap-swap-instructions) — Add hidden docs page for /quote, /swap, /swap-instructions

## Checklist

- [x] `node generate-llms-from-docs.js` run (hidden page correctly excluded; `llms.txt` unchanged at 228 entries)
- [x] `mint broken-links` passes
- [x] Page has `title`, `description`, and `llmsDescription`
- [x] `docs.json` nav intentionally NOT updated (hidden-page convention per the 2026-04-06 IA decision in `.claude/rules/decisions.md`)
- [x] Redirects: N/A (new page, no path changes)
- [x] Changelog: N/A (private integrator docs, not a public API launch)
- [x] `.claude/rules/product-learning.md` updated
