### PR TITLE
[Swap] Add hidden positive slippage collection docs for /order and /build

### DIFF
--- a/swap/positive-slippage.mdx
+++ b/swap/positive-slippage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Positive Slippage"
 description: "Collect a share of positive slippage on /order and /build swaps"
-llmsDescription: "Enterprise-only positive slippage collection on the Jupiter Swap V2 API. Whitelisted integrators pass the positiveSlippageBps query parameter (0–10000) to GET /swap/v2/order or GET /swap/v2/build to claim a share of positive slippage on swaps where the realised output exceeds the quoted output. Value 0 (default) sends all positive slippage to the user; 10000 sends all positive slippage to the integrator; intermediate values split proportionally. Access is gated by a case-by-case whitelist coordinated through an existing Jupiter contact; the organisation ID registered with the API gateway must match. Fee settlement enrolment is not a prerequisite. Two collection paths are offered: a Jupiter-managed collector wallet (recommended, Jupiter holds ATAs for every mint and pays out a single monthly USDC amount) or a direct collector wallet supplied by the integrator (Jupiter sends every collected mint as-is, integrator opens and maintains ATAs). The Jupiter/integrator share of the integrator's portion is agreed during whitelisting and mirrors the fee settlement split when the integrator is enrolled. The collection mechanism is identical for /order and /build."
+llmsDescription: "Enterprise-only positive slippage collection on the Jupiter Swap V2 API. Whitelisted integrators pass the positiveSlippageBps query parameter (0–10000) to GET /swap/v2/order or GET /swap/v2/build to claim a share of positive slippage on swaps where the realised output exceeds the quoted output. Value 0 (default) sends all positive slippage to the user; 10000 sends all positive slippage to the integrator; intermediate values split proportionally. Access is gated by a case-by-case whitelist coordinated through an existing Jupiter contact. The integrator's share is collected in a Jupiter-managed wallet: Jupiter holds ATAs for every mint, swaps incoming balances to USDC at regular intervals, and pays out a single monthly USDC amount to the integrator's designated payout address. The Jupiter/integrator split is agreed during whitelisting. A self-managed collector wallet is not yet supported. The collection mechanism is identical for /order and /build."
 hidden: true
 ---
 
@@ -9,7 +9,7 @@ Positive slippage is the amount by which a swap's realised output exceeds the qu
 
 ## Eligibility
 
-Access is evaluated case by case and applies independently of whether you are enrolled in the fee settlement service or which endpoint you integrate (`/order` or `/build`).
+Access is evaluated case by case and applies to both `/order` and `/build` integrations.
 
 Before `positiveSlippageBps` has any effect, Jupiter must whitelist your organisation. To request whitelisting:
 
@@ -71,25 +71,19 @@ curl -G "https://api.jup.ag/swap/v2/build" \
 
 ## Revenue distribution
 
-The user's share of positive slippage (`10000 − positiveSlippageBps` bps) is settled to the `taker` on-chain at swap time. Your share lands in a collector wallet. You choose one of two collection paths during whitelisting.
+The user's share of positive slippage (`10000 − positiveSlippageBps` bps) is settled to the `taker` on-chain at swap time. The integrator's share is collected in a Jupiter-managed wallet: Jupiter opens and maintains ATAs for every mint that flows into it, swaps incoming balances to USDC at regular intervals, and sends a single monthly USDC payout to your designated payout address.
 
-### Jupiter-managed collector (recommended)
-
-Jupiter holds the collector wallet, opens and maintains ATAs for every mint that flows into it, swaps incoming balances to USDC at regular intervals, and sends a single monthly USDC payout to your designated payout address.
-
-Most integrators choose this path. Positive slippage can arrive in any mint, including long-tail assets where Solana liquidity moves quickly. Opening per-mint ATAs and converting balances yourself adds up in cost and operational overhead.
+Positive slippage can arrive in any mint, including long-tail assets where Solana liquidity moves quickly. Opening per-mint ATAs and converting balances yourself adds up in cost and operational overhead; Jupiter handles this for you.
 
 You are responsible for:
 - The payout wallet address that Jupiter sends to.
 - Initialising the USDC ATA on that wallet before the first payout.
 
-### Direct collector
+The integrator portion (`positiveSlippageBps` bps of the realised positive slippage) is split between Jupiter and you. The exact split is agreed during whitelisting.
 
-You provide a wallet address you control. Jupiter sends every collected mint to that address as-is, with no conversion. You open and maintain the ATAs for every mint you expect to receive and run any USDC conversion yourself.
-
-### Jupiter and integrator split
-
-Across both paths, the integrator portion of the positive slippage (`positiveSlippageBps` bps of the realised amount) is split between Jupiter and you. The exact split is agreed during whitelisting and mirrors your fee settlement split if you are enrolled.
+<Note>
+A self-managed collector wallet (where Jupiter sends collected mints to a wallet you control instead of converting and paying out monthly) is not yet supported. If you need this option, raise it with your Jupiter contact.
+</Note>
 
 ## Related
 

--- a/swap/positive-slippage.mdx
+++ b/swap/positive-slippage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Positive Slippage"
 description: "Collect a share of positive slippage on /order and /build swaps"
-llmsDescription: "Enterprise-only positive slippage collection on the Jupiter Swap V2 API. Whitelisted integrators pass the positiveSlippageBps query parameter (0–10000) to GET /swap/v2/order or GET /swap/v2/build to claim a share of positive slippage on swaps where the realised output exceeds the quoted output. Value 0 (default) sends all positive slippage to the user; 10000 sends all positive slippage to the integrator; intermediate values split proportionally. Access is gated by a case-by-case whitelist coordinated through an existing Jupiter contact. The integrator's share is collected in a Jupiter-managed wallet: Jupiter holds ATAs for every mint, swaps incoming balances to USDC at regular intervals, and pays out a single monthly USDC amount to the integrator's designated payout address. The Jupiter/integrator split is agreed during whitelisting. A self-managed collector wallet is not yet supported. The collection mechanism is identical for /order and /build."
+llmsDescription: "Enterprise-only positive slippage collection on the Jupiter Swap V2 API. Whitelisted integrators pass the positiveSlippageBps query parameter (0–10000) to GET /swap/v2/order or GET /swap/v2/build to claim a share of positive slippage on swaps where the realised output exceeds the quoted output. Value 0 (default) sends all positive slippage to the user; 10000 sends all positive slippage to the integrator; intermediate values split proportionally. Access is gated by a case-by-case whitelist arranged directly with the Jupiter team. The integrator's share is collected in a Jupiter-managed wallet: Jupiter holds ATAs for every mint, swaps incoming balances to USDC at regular intervals, and pays out a single monthly USDC amount to the integrator's designated payout address. The Jupiter/integrator split is agreed during whitelisting. A self-managed collector wallet is not yet supported. The collection mechanism is identical for /order and /build."
 hidden: true
 ---
 
@@ -14,7 +14,7 @@ Access is evaluated case by case and applies to both `/order` and `/build` integ
 Before `positiveSlippageBps` has any effect, Jupiter must whitelist your organisation. To request whitelisting:
 
 1. Find your organisation ID under Settings in the [Developer Platform](https://developers.jup.ag/portal).
-2. Share that organisation ID with your Jupiter contact.
+2. Send that organisation ID to us.
 3. Jupiter manually enables positive slippage on the matching organisation ID.
 
 If `positiveSlippageBps` is not passed, the user receives 100% of any positive slippage as usual.
@@ -82,7 +82,7 @@ You are responsible for:
 The integrator portion (`positiveSlippageBps` bps of the realised positive slippage) is split between Jupiter and you. The exact split is agreed during whitelisting.
 
 <Note>
-A self-managed collector wallet (where Jupiter sends collected mints to a wallet you control instead of converting and paying out monthly) is not yet supported. If you need this option, raise it with your Jupiter contact.
+A self-managed collector wallet (where Jupiter sends collected mints to a wallet you control instead of converting and paying out monthly) is not yet supported. Let us know if you need it.
 </Note>
 
 ## Related

--- a/swap/positive-slippage.mdx
+++ b/swap/positive-slippage.mdx
@@ -13,9 +13,9 @@ Access is evaluated case by case and applies to both `/order` and `/build` integ
 
 Before `positiveSlippageBps` has any effect, Jupiter must whitelist your organisation. To request whitelisting:
 
-1. Find your organisation ID under Settings in the [Developer Platform](https://developers.jup.ag/portal).
-2. Send that organisation ID to us.
-3. Jupiter manually enables positive slippage on the matching organisation ID.
+1. Find your **organisation ID** under Settings in the [Developer Platform](https://developers.jup.ag/portal).
+2. Send it to us.
+3. We enable positive slippage for that organisation.
 
 If `positiveSlippageBps` is not passed, the user receives 100% of any positive slippage as usual.
 
@@ -79,7 +79,7 @@ You are responsible for:
 - The payout wallet address that Jupiter sends to.
 - Initialising the USDC ATA on that wallet before the first payout.
 
-The integrator portion (`positiveSlippageBps` bps of the realised positive slippage) is split between Jupiter and you. The exact split is agreed during whitelisting.
+The integrator's share (positive slippage minus the user's share) is split between Jupiter and you. The exact split is agreed during whitelisting.
 
 <Note>
 A self-managed collector wallet (where Jupiter sends collected mints to a wallet you control instead of converting and paying out monthly) is not yet supported. Let us know if you need it.

--- a/swap/positive-slippage.mdx
+++ b/swap/positive-slippage.mdx
@@ -7,17 +7,13 @@ hidden: true
 
 Positive slippage is the amount by which a swap's realised output exceeds the quoted output. By default, the entire positive slippage goes back to the user. Whitelisted enterprise integrators can claim a configurable share by passing `positiveSlippageBps` on `/order` or `/build`.
 
-<Note>
-Positive slippage collection is opt-in and gated by a manual whitelist. Coordinate access through your existing Jupiter contact before passing `positiveSlippageBps` in production traffic.
-</Note>
-
 ## Eligibility
 
 Access is evaluated case by case and applies independently of whether you are enrolled in the fee settlement service or which endpoint you integrate (`/order` or `/build`).
 
 Before `positiveSlippageBps` has any effect, Jupiter must whitelist your organisation. To request whitelisting:
 
-1. Confirm your organisation ID is registered with the API gateway (the same ID used to authenticate your API key).
+1. Find your organisation ID under Settings in the [Developer Platform](https://developers.jup.ag/portal).
 2. Share that organisation ID with your Jupiter contact.
 3. Jupiter manually enables positive slippage on the matching organisation ID.
 
@@ -27,11 +23,11 @@ If `positiveSlippageBps` is not passed, the user receives 100% of any positive s
 
 | Parameter             | Type     | Range    | Default | Description                                                                 |
 |-----------------------|----------|----------|---------|-----------------------------------------------------------------------------|
-| `positiveSlippageBps` | `number` | `0–10000`| `0`     | Share of positive slippage routed to the integrator's collector pool, in bps |
+| `positiveSlippageBps` | `number` | `0–10000`| `0`     | Share of positive slippage routed to the integrator's collector wallet, in bps |
 
 - `0` (default): user receives 100% of the positive slippage.
-- `10000`: integrator's collector pool receives 100% of the positive slippage; user receives 0.
-- Any value in between: split proportionally. For example, `5000` sends 50% to the integrator's collector pool and 50% to the user.
+- `10000`: integrator's collector wallet receives 100% of the positive slippage; user receives 0.
+- Any value in between: split proportionally. For example, `5000` sends 50% to the integrator's collector wallet and 50% to the user.
 
 The split is applied per swap, at execution time.
 
@@ -53,7 +49,7 @@ curl -G "https://api.jup.ag/swap/v2/order" \
   --data-urlencode "positiveSlippageBps=5000"
 ```
 
-No other changes are required. The returned transaction routes the user's share back to the taker and the integrator's share to the collector wallet configured during whitelisting.
+No other changes are required. The returned transaction routes the user's share back to the `taker` and the integrator's share to the collector wallet configured during whitelisting.
 
 ## Using with `/build`
 
@@ -75,7 +71,7 @@ curl -G "https://api.jup.ag/swap/v2/build" \
 
 ## Revenue distribution
 
-The user's share of positive slippage (`10000 − positiveSlippageBps` bps) is settled to the taker on-chain at swap time. Your share lands in a collector wallet. You choose one of two collection paths during whitelisting.
+The user's share of positive slippage (`10000 − positiveSlippageBps` bps) is settled to the `taker` on-chain at swap time. Your share lands in a collector wallet. You choose one of two collection paths during whitelisting.
 
 ### Jupiter-managed collector (recommended)
 
@@ -93,7 +89,7 @@ You provide a wallet address you control. Jupiter sends every collected mint to 
 
 ### Jupiter and integrator split
 
-Across both paths, the integrator portion of the positive slippage (`positiveSlippageBps` bps of the realised amount) is split between Jupiter and you. The exact split is agreed during whitelisting and mirrors your fee settlement split if you are enrolled (for example `80/20` or `85/15`).
+Across both paths, the integrator portion of the positive slippage (`positiveSlippageBps` bps of the realised amount) is split between Jupiter and you. The exact split is agreed during whitelisting and mirrors your fee settlement split if you are enrolled.
 
 ## Related
 

--- a/swap/positive-slippage.mdx
+++ b/swap/positive-slippage.mdx
@@ -1,0 +1,102 @@
+---
+title: "Positive Slippage"
+description: "Collect a share of positive slippage on /order and /build swaps"
+llmsDescription: "Enterprise-only positive slippage collection on the Jupiter Swap V2 API. Whitelisted integrators pass the positiveSlippageBps query parameter (0–10000) to GET /swap/v2/order or GET /swap/v2/build to claim a share of positive slippage on swaps where the realised output exceeds the quoted output. Value 0 (default) sends all positive slippage to the user; 10000 sends all positive slippage to the integrator; intermediate values split proportionally. Access is gated by a case-by-case whitelist coordinated through an existing Jupiter contact; the organisation ID registered with the API gateway must match. Fee settlement enrolment is not a prerequisite. Two collection paths are offered: a Jupiter-managed collector wallet (recommended, Jupiter holds ATAs for every mint and pays out a single monthly USDC amount) or a direct collector wallet supplied by the integrator (Jupiter sends every collected mint as-is, integrator opens and maintains ATAs). The Jupiter/integrator share of the integrator's portion is agreed during whitelisting and mirrors the fee settlement split when the integrator is enrolled. The collection mechanism is identical for /order and /build."
+hidden: true
+---
+
+Positive slippage is the amount by which a swap's realised output exceeds the quoted output. By default, the entire positive slippage goes back to the user. Whitelisted enterprise integrators can claim a configurable share by passing `positiveSlippageBps` on `/order` or `/build`.
+
+<Note>
+Positive slippage collection is opt-in and gated by a manual whitelist. Coordinate access through your existing Jupiter contact before passing `positiveSlippageBps` in production traffic.
+</Note>
+
+## Eligibility
+
+Access is evaluated case by case and applies independently of whether you are enrolled in the fee settlement service or which endpoint you integrate (`/order` or `/build`).
+
+Before `positiveSlippageBps` has any effect, Jupiter must whitelist your organisation. To request whitelisting:
+
+1. Confirm your organisation ID is registered with the API gateway (the same ID used to authenticate your API key).
+2. Share that organisation ID with your Jupiter contact.
+3. Jupiter manually enables positive slippage on the matching organisation ID.
+
+If `positiveSlippageBps` is not passed, the user receives 100% of any positive slippage as usual.
+
+## The `positiveSlippageBps` parameter
+
+| Parameter             | Type     | Range    | Default | Description                                                                 |
+|-----------------------|----------|----------|---------|-----------------------------------------------------------------------------|
+| `positiveSlippageBps` | `number` | `0–10000`| `0`     | Share of positive slippage routed to the integrator's collector pool, in bps |
+
+- `0` (default): user receives 100% of the positive slippage.
+- `10000`: integrator's collector pool receives 100% of the positive slippage; user receives 0.
+- Any value in between: split proportionally. For example, `5000` sends 50% to the integrator's collector pool and 50% to the user.
+
+The split is applied per swap, at execution time.
+
+## Using with `/order`
+
+Append `positiveSlippageBps` as a query parameter on the [`/order`](/swap/order-and-execute) request.
+
+```
+GET https://api.jup.ag/swap/v2/order
+```
+
+```bash
+curl -G "https://api.jup.ag/swap/v2/order" \
+  -H "x-api-key: $JUPITER_API_KEY" \
+  --data-urlencode "inputMint=So11111111111111111111111111111111111111112" \
+  --data-urlencode "outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" \
+  --data-urlencode "amount=1000000000" \
+  --data-urlencode "taker=$TAKER" \
+  --data-urlencode "positiveSlippageBps=5000"
+```
+
+No other changes are required. The returned transaction routes the user's share back to the taker and the integrator's share to the collector wallet configured during whitelisting.
+
+## Using with `/build`
+
+Append `positiveSlippageBps` as a query parameter on the [`/build`](/swap/build) request. The split is applied in the same way.
+
+```
+GET https://api.jup.ag/swap/v2/build
+```
+
+```bash
+curl -G "https://api.jup.ag/swap/v2/build" \
+  -H "x-api-key: $JUPITER_API_KEY" \
+  --data-urlencode "inputMint=So11111111111111111111111111111111111111112" \
+  --data-urlencode "outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" \
+  --data-urlencode "amount=1000000000" \
+  --data-urlencode "taker=$TAKER" \
+  --data-urlencode "positiveSlippageBps=5000"
+```
+
+## Revenue distribution
+
+The user's share of positive slippage (`10000 − positiveSlippageBps` bps) is settled to the taker on-chain at swap time. Your share lands in a collector wallet. You choose one of two collection paths during whitelisting.
+
+### Jupiter-managed collector (recommended)
+
+Jupiter holds the collector wallet, opens and maintains ATAs for every mint that flows into it, swaps incoming balances to USDC at regular intervals, and sends a single monthly USDC payout to your designated payout address.
+
+Most integrators choose this path. Positive slippage can arrive in any mint, including long-tail assets where Solana liquidity moves quickly. Opening per-mint ATAs and converting balances yourself adds up in cost and operational overhead.
+
+You are responsible for:
+- The payout wallet address that Jupiter sends to.
+- Initialising the USDC ATA on that wallet before the first payout.
+
+### Direct collector
+
+You provide a wallet address you control. Jupiter sends every collected mint to that address as-is, with no conversion. You open and maintain the ATAs for every mint you expect to receive and run any USDC conversion yourself.
+
+### Jupiter and integrator split
+
+Across both paths, the integrator portion of the positive slippage (`positiveSlippageBps` bps of the realised amount) is split between Jupiter and you. The exact split is agreed during whitelisting and mirrors your fee settlement split if you are enrolled (for example `80/20` or `85/15`).
+
+## Related
+
+- [Order & Execute](/swap/order-and-execute): the Meta-Aggregator path that supports `positiveSlippageBps`.
+- [Build](/swap/build): the Router path that supports `positiveSlippageBps`.
+- [Referral Program](/tool-kits/referral-program): the non-enterprise path for earning a share of swap fees on `/order`.


### PR DESCRIPTION
## Summary
Adds a hidden Mintlify page documenting positive slippage collection for whitelisted enterprise integrators on `/order` and `/build`. Follows the existing hidden-page pattern (`multisig.mdx`, `quote-and-swap.mdx`): flat under `swap/`, `hidden: true`, not added to `docs.json` navigation, auto-excluded from `llms.txt`.

## Changes
- New page at `swap/positive-slippage.mdx`
- Covers: the `positiveSlippageBps` query parameter (0–10000), eligibility/whitelist process, `/order` and `/build` usage with minimal cURL snippets, two revenue distribution paths (Jupiter-managed collector vs. integrator-supplied direct collector)

## Linear Issues
- Fixes [DEVREL-184](https://linear.app/raccoons/issue/DEVREL-184/swap-add-hidden-positive-slippage-collection-docs-for-order-and-build) — [Swap] Add hidden positive slippage collection docs for /order and /build

## Checklist
- [x] `node generate-llms-from-docs.js` run — hidden page correctly excluded from `llms.txt`
- [x] `mint broken-links` passes
- [x] Page has `title`, `description`, `llmsDescription`
- [x] `docs.json` navigation NOT updated (hidden page, per the pattern in [decisions.md DEVREL-165](.claude/rules/decisions.md))
- [x] No redirects needed (new path)
- [x] No changelog entry (hidden integrator doc, not a public API change)
- [x] `.claude/rules/` not updated (no new product learnings beyond what the doc itself captures)
