### PR TITLE
chore: deprecate Content API documentation

### DIFF
--- a/api-reference/tokens/get-content-cooking.mdx
+++ b/api-reference/tokens/get-content-cooking.mdx
@@ -2,4 +2,6 @@
 openapi: /openapi-spec/content/content.yaml get /content/cooking
 title: "Get Content Cooking"
 description: "Retrieves approved content for currently trending tokens on Jupiter"
+llmsDescription: "DEPRECATED — GET /tokens/v2/content/cooking retrieves approved content for currently trending tokens. Being phased out in favour of an upcoming replacement."
+deprecated: true
 ---

--- a/api-reference/tokens/get-content-feed.mdx
+++ b/api-reference/tokens/get-content-feed.mdx
@@ -2,4 +2,6 @@
 openapi: /openapi-spec/content/content.yaml get /content/feed
 title: "Get Content Feed"
 description: "Retrieves a paginated feed of content for a specific mint"
+llmsDescription: "DEPRECATED — GET /tokens/v2/content/feed retrieves a paginated feed of content for a specific mint. Being phased out in favour of an upcoming replacement."
+deprecated: true
 ---

--- a/api-reference/tokens/get-content.mdx
+++ b/api-reference/tokens/get-content.mdx
@@ -2,4 +2,6 @@
 openapi: /openapi-spec/content/content.yaml get /content
 title: "Get Content"
 description: "Retrieves approved content for up to 50 Solana token mint addresses"
+llmsDescription: "DEPRECATED — GET /tokens/v2/content retrieves approved content for up to 50 Solana token mint addresses. Being phased out in favour of an upcoming replacement."
+deprecated: true
 ---

--- a/docs.json
+++ b/docs.json
@@ -123,8 +123,7 @@
                 "pages": [
                   "tokens/index",
                   "tokens/token-information",
-                  "tokens/verification",
-                  "tokens/content"
+                  "tokens/verification"
                 ]
               },
               {
@@ -149,14 +148,6 @@
                       "api-reference/tokens/verify-check-eligibility",
                       "api-reference/tokens/verify-craft-txn",
                       "api-reference/tokens/verify-execute"
-                    ]
-                  },
-                  {
-                    "group": "Content",
-                    "pages": [
-                      "api-reference/tokens/get-content",
-                      "api-reference/tokens/get-content-cooking",
-                      "api-reference/tokens/get-content-feed"
                     ]
                   }
                 ]

--- a/llms.txt
+++ b/llms.txt
@@ -102,7 +102,6 @@ Token metadata, search, verification, and organic score APIs.
 - [Tokens API](https://developers.jup.ag/docs/tokens/index.md): Jupiter Tokens API V2 for programmatic token discovery and metadata. Search by name/symbol/mint, get verification status, organic score, holder count, market cap, and trading stats. Covers verification levels (verified, unverified, banned), organic score methodology, and token tag standard.
 - [Token Information](https://developers.jup.ag/docs/tokens/token-information.md): GET /tokens/v2 endpoints for retrieving token metadata by mint address, symbol search, tag, category, or recency. Returns name, symbol, icon, organic score, holder count, and trading stats.
 - [Express Verification API](https://developers.jup.ag/docs/tokens/verification.md): Jupiter VRFD Express Verification API for programmatic token verification and metadata updates. Three-step flow: check eligibility (GET /tokens/v2/verify/express/check-eligibility), craft a 1000 JUP payment transaction (GET /tokens/v2/verify/express/craft-txn), then execute with signed transaction and token details (POST /tokens/v2/verify/express/execute). Used by launchpads, agents, and projects to submit tokens for Jupiter verification without the UI. Requires an API key from developers.jup.ag/portal. Verification and metadata updates are reviewed independently by the VRFD team.
-- [Content API (BETA)](https://developers.jup.ag/docs/tokens/content.md): GET /tokens/v2/content endpoints for retrieving curated token content, trending tokens, paginated feeds, and summaries powered by Jupiter VRFD.
 
 ### Guides
 
@@ -122,12 +121,6 @@ Token metadata, search, verification, and organic score APIs.
 - [Check Eligibility](https://developers.jup.ag/docs/openapi-spec/tokens/v2/verification.yaml): Check if a token is eligible for express verification and metadata updates
 - [Craft Transaction](https://developers.jup.ag/docs/openapi-spec/tokens/v2/verification.yaml): Craft an unsigned 1000 JUP payment transaction for express verification
 - [Execute](https://developers.jup.ag/docs/openapi-spec/tokens/v2/verification.yaml): Submit signed transaction with verification and metadata details
-
-#### Content
-
-- [Get Content](https://developers.jup.ag/docs/openapi-spec/content/content.yaml): Retrieves approved content for up to 50 Solana token mint addresses
-- [Get Content Cooking](https://developers.jup.ag/docs/openapi-spec/content/content.yaml): Retrieves approved content for currently trending tokens on Jupiter
-- [Get Content Feed](https://developers.jup.ag/docs/openapi-spec/content/content.yaml): Retrieves a paginated feed of content for a specific mint
 
 ## Price
 

--- a/portal/plans.mdx
+++ b/portal/plans.mdx
@@ -105,9 +105,6 @@ Credit costs are subject to change. The latest costs are always reflected in you
     | `/tokens/v2/tag` | 50 |
     | `/tokens/v2/{category}/{interval}` | 5 |
     | `/tokens/v2/recent` | 1 |
-    | `/tokens/v2/content` | 1 |
-    | `/tokens/v2/content/feed` | 1 |
-    | `/tokens/v2/content/cooking` | 1 |
   </Accordion>
 
   <Accordion title="Price">

--- a/tokens/content.mdx
+++ b/tokens/content.mdx
@@ -2,12 +2,13 @@
 title: "Content API (BETA)"
 sidebarTitle: "Content"
 description: "Get content for multiple mints, trending tokens or paginated content feed."
-llmsDescription: "GET /tokens/v2/content endpoints for retrieving curated token content, trending tokens, paginated feeds, and summaries powered by Jupiter VRFD."
+llmsDescription: "DEPRECATED — Content API endpoints (/tokens/v2/content, /content/feed, /content/cooking) are being phased out. A more comprehensive replacement is in development as part of an upcoming Tokens API update. Existing integrators should reach out via Discord to discuss the transition."
+deprecated: true
 ---
 
-<Note>
-  The Content API is available on all tiers. Refer to [Getting Started](/portal/setup) for API key setup.
-</Note>
+<Warning>
+**The Content API is deprecated.** We are building a more comprehensive replacement as part of an upcoming Tokens API update. If you are currently using the Content API, [reach out via Discord](https://discord.gg/jup) to discuss the transition.
+</Warning>
 
 ## About Content API
 

--- a/tokens/content.mdx
+++ b/tokens/content.mdx
@@ -2,12 +2,12 @@
 title: "Content API (BETA)"
 sidebarTitle: "Content"
 description: "Get content for multiple mints, trending tokens or paginated content feed."
-llmsDescription: "DEPRECATED — Content API endpoints (/tokens/v2/content, /content/feed, /content/cooking) are being phased out. A more comprehensive replacement is in development as part of an upcoming Tokens API update. Existing integrators should reach out via Discord to discuss the transition."
+llmsDescription: "DEPRECATED — Content API endpoints (/tokens/v2/content, /content/feed, /content/cooking) are being deprecated in favor of a more comprehensive replacement, coming as part of an upcoming Tokens API update. Existing integrators should reach out to @9yointern on Twitter for continued access."
 deprecated: true
 ---
 
 <Warning>
-**The Content API is deprecated.** We are building a more comprehensive replacement as part of an upcoming Tokens API update. If you are currently using the Content API, [reach out via Discord](https://discord.gg/jup) to discuss the transition.
+The Content API is being deprecated in favor of a more comprehensive replacement, coming as part of an upcoming Tokens API update. If you currently rely on the Content API, please reach out on Twitter and contact [9yointern](https://x.com/9yointern) — we'd love to fold your feedback into the next iteration and get you whitelisted for continued access.
 </Warning>
 
 ## About Content API

--- a/tokens/index.mdx
+++ b/tokens/index.mdx
@@ -20,7 +20,7 @@ Token verification on Solana has evolved through several iterations: from the or
 | **Organic Score** | 0-100 score measuring genuine trading activity |
 | **Trading Stats** | Volume, price change, buy/sell counts across intervals (5m, 1h, 6h, 24h) |
 | **Market Data** | Holder count, market cap, liquidity |
-| **Content** | Community-submitted text posts, tweets, summaries |
+| **Content** | Community-submitted text posts, tweets, summaries *(deprecated)* |
 
 ## Verification Levels
 
@@ -87,5 +87,4 @@ To get your tokens tagged:
 
 - [Token Information](/tokens/token-information) for the full response schema and field reference
 - [Express Verification](/tokens/verification) to submit tokens for verification via API
-- [Content](/tokens/content) for community-submitted token content and feeds
 - [Get Token Information guide](/guides/how-to-get-token-information) for a step-by-step integration tutorial


### PR DESCRIPTION
## Summary

Deprecates the Content API documentation. The Content API is being phased out in favour of a more comprehensive replacement as part of an upcoming Tokens API update. No specific sunset date yet.

## Changes

- Added `deprecated: true` frontmatter to all 4 Content API pages (1 docs + 3 API reference)
- Added deprecation `<Warning>` callout to `tokens/content.mdx` directing users to Discord
- Prefixed `llmsDescription` with `DEPRECATED` on all Content API pages
- Removed Content API from `docs.json` navigation (docs + API reference groups)
- Removed Content API credit costs from `portal/plans.mdx`
- Marked Content row as *(deprecated)* in Tokens overview table
- Removed Content link from Tokens "Learn More" section
- Regenerated `llms.txt` (Content API entries excluded)

## Checklist
- [x] `node generate-llms-from-docs.js` run
- [x] `mint broken-links` passes
- [x] All pages have `title`, `description`, `llmsDescription`
- [x] `docs.json` navigation updated
- [x] Redirects added (if paths changed) — N/A, no paths changed
- [x] `.claude/rules/` updated with any learnings or decisions — N/A
