### PR TITLE
fix: rename iris to metis across all docs

### DIFF
--- a/.claude/rules/style-guide.md
+++ b/.claude/rules/style-guide.md
@@ -40,7 +40,7 @@ Technical but approachable. Professional and precise, not cold or overly formal.
 | Term                        | Definition / Usage                                                |
 |-----------------------------|-------------------------------------------------------------------|
 | Juno                        | Jupiter's liquidity engine (multi-source aggregation, self-learning) |
-| Iris                        | Jupiter's routing engine for DEX integrations                     |
+| Metis                       | Jupiter's onchain routing engine for DEX integrations. API router value: `metis`. Do not use "Iris" (legacy name). |
 | JupiterZ                    | RFQ-based routing engine for market maker integrations            |
 | Jupiter Beam                | Transaction landing infrastructure (sub-second)                   |
 | RTSE                        | Real-Time Slippage Estimator — always define on first use per page |

--- a/guides/how-to-build-a-swap-with-ultra.mdx
+++ b/guides/how-to-build-a-swap-with-ultra.mdx
@@ -142,8 +142,8 @@ print(f"Swap {order['inAmount']} → {order['outAmount']}")
 | `taker` | No | User's wallet address. Required to get a signable transaction. Omit to get a quote only (useful for showing price before wallet connect). |
 | `referralAccount` | No | Referral account for [integrator fees](/ultra/add-fees-to-ultra) |
 | `referralFee` | No | Referral fee in basis points (50-255) |
-| `excludeRouters` | No | [Manual mode](/ultra/gasless) only. Comma-separated routers to exclude: `iris`, `jupiterz`, `dflow`, `okx` |
-| `excludeDexes` | No | [Manual mode](/ultra/gasless) only. Comma-separated DEXs to exclude (applies to Iris router only). [Full list of DEXs](/api-reference/swap/v1/program-id-to-label). |
+| `excludeRouters` | No | [Manual mode](/ultra/gasless) only. Comma-separated routers to exclude: `metis`, `jupiterz`, `dflow`, `okx` |
+| `excludeDexes` | No | [Manual mode](/ultra/gasless) only. Comma-separated DEXs to exclude (applies to Metis router only). [Full list of DEXs](/api-reference/swap/v1/program-id-to-label). |
 
 **What you get back:**
 
@@ -152,7 +152,7 @@ print(f"Swap {order['inAmount']} → {order['outAmount']}")
 | `transaction` | Base64 unsigned transaction. Sign this. `null` if you didn't pass `taker`. |
 | `requestId` | Pass this to `/execute`. It's how Ultra tracks your order. |
 | `outAmount` | Expected output in native token units |
-| `router` | Which router won the auction: `iris`, `jupiterz`, `dflow`, `okx` |
+| `router` | Which router won the auction: `metis`, `jupiterz`, `dflow`, `okx` |
 | `gasless` | `true` if this swap is gasless |
 | `slippageBps` | Slippage tolerance set by RTSE (you don't need to configure this) |
 | `feeBps` | Total fee in basis points |
@@ -327,7 +327,7 @@ interface OrderResponse {
   swapMode: string;                // "ExactIn"
   slippageBps: number;             // Set automatically by RTSE
   routePlan: RoutePlan[];
-  router: 'iris' | 'jupiterz' | 'dflow' | 'okx';
+  router: 'metis' | 'jupiterz' | 'dflow' | 'okx';
   transaction: string | null;      // Base64 unsigned tx (null if no taker)
   requestId: string;               // Pass to /execute
   gasless: boolean;
@@ -424,7 +424,7 @@ For the full list of error codes including aggregator and RFQ-specific codes, se
 
 Ultra handles gasless automatically. You don't configure anything.
 
-**Ultra Gasless Support (Iris).** When the taker has less than 0.01 SOL and the trade is at least ~$10, Jupiter covers everything: network fee, priority fee, token account rent, and other accounts rent (e.g. DEX-specific accounts). The cost gets deducted from the swap output (you'll see it in `feeBps`).
+**Ultra Gasless Support (Metis).** When the taker has less than 0.01 SOL and the trade is at least ~$10, Jupiter covers everything: network fee, priority fee, token account rent, and other accounts rent (e.g. DEX-specific accounts). The cost gets deducted from the swap output (you'll see it in `feeBps`).
 
 **JupiterZ (RFQ).** When a market maker provides the route, the market maker pays network and priority fees. If the taker's output token account does not exist, Jupiter's gas wallet pays the rent to create it.
 

--- a/openapi-spec/swap/v2/swap.yaml
+++ b/openapi-spec/swap/v2/swap.yaml
@@ -267,7 +267,7 @@ paths:
             type: string
           description: |
             - Comma-separated list of routers to exclude
-            - Available routers: `iris` (Metis), `jupiterz` (JupiterZ), `dflow`, `okx`
+            - Available routers: `metis`, `jupiterz`, `dflow`, `okx`
           example: jupiterz,dflow
         - name: excludeDexes
           in: query
@@ -353,7 +353,7 @@ paths:
                     enum: [aggregator, rfq, aggregator+rfq, dflow, okx]
                   router:
                     type: string
-                    enum: [iris, jupiterz, dflow, okx]
+                    enum: [metis, jupiterz, dflow, okx]
                     description: Which router won the quote
                   transaction:
                     type: string

--- a/openapi-spec/ultra/ultra.yaml
+++ b/openapi-spec/ultra/ultra.yaml
@@ -148,7 +148,7 @@ paths:
                   router:
                     type: string
                     enum:
-                      - iris
+                      - metis
                       - jupiterz
                       - dflow
                       - okx
@@ -258,7 +258,7 @@ paths:
                 rentFeeLamports: 0
                 rentFeePayer: null
                 swapType: "aggregator"
-                router: "iris"
+                router: "metis"
                 transaction: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAEN..."
                 gasless: false
                 requestId: "b5e5f3a7-8c4d-4e2f-9a1b-3c6d8e0f2a4b"
@@ -366,7 +366,7 @@ paths:
           schema:
             type: string
             enum:
-              - iris
+              - metis
               - jupiterz
               - dflow
               - okx
@@ -375,10 +375,10 @@ paths:
           name: excludeDexes
           description: |
             - [Full list of DEXes here](https://developers.jup.ag/docs/api-reference/swap/program-id-to-label), for example: `excludeDexes=Raydium,Orca+V2,Meteora+DLMM`
-            - **Important**: This only excludes DEXes on the Iris router, does not apply to other routers
+            - **Important**: This only excludes DEXes on the Metis router, does not apply to other routers
             - For example:
-              - **Exclude** Raydium: `excludeRouters=<all-except-Iris>` and `excludeDexes=Raydium`
-              - **Only include** Meteora DLMM: `excludeRouters=<all-except-Iris>` and `excludeDexes=<all-except-MeteoraDLMM>`
+              - **Exclude** Raydium: `excludeRouters=<all-except-metis>` and `excludeDexes=Raydium`
+              - **Only include** Meteora DLMM: `excludeRouters=<all-except-metis>` and `excludeDexes=<all-except-MeteoraDLMM>`
           schema:
             type: string
         
@@ -722,7 +722,7 @@ paths:
                     name:
                       type: string
                       enum:
-                        - Iris
+                        - Metis
                         - JupiterZ
                         - DFlow
                         - OKX DEX Router

--- a/swap/order-and-execute.mdx
+++ b/swap/order-and-execute.mdx
@@ -85,7 +85,7 @@ type OrderResponse = {
   transaction: string | null; // base64-encoded transaction, null if no taker, "" if quote-only
   requestId: string;
   outAmount: string;
-  router: string;            // "iris" | "jupiterz" | "dflow" | "okx"
+  router: string;            // "metis" | "jupiterz" | "dflow" | "okx"
   mode: string;              // "ultra" | "manual"
   feeBps: number;
   feeMint: string;
@@ -120,7 +120,7 @@ type OrderResponse = {
   transaction: string | null; // base64-encoded transaction, null if no taker, "" if quote-only
   requestId: string;
   outAmount: string;
-  router: string;            // "iris" | "jupiterz" | "dflow" | "okx"
+  router: string;            // "metis" | "jupiterz" | "dflow" | "okx"
   mode: string;              // "ultra" | "manual"
   feeBps: number;
   feeMint: string;
@@ -298,7 +298,7 @@ if (result.status === "Success") {
 | `transaction` | Base64-encoded transaction to sign. Null if `taker` is not set. Empty string (`""`) if the router could quote a price but could not build a transaction (check `errorCode`). |
 | `requestId` | Pass this to `/execute`. |
 | `outAmount` | Expected output amount before slippage. |
-| `router` | Which router won the quote (iris, jupiterz, dflow, okx). |
+| `router` | Which router won the quote (`metis`, `jupiterz`, `dflow`, `okx`). |
 | `mode` | "ultra" (no optional params) or "manual" (optional params used). |
 | `errorCode` | Present when `transaction` is `""`. Match on `router` + `errorCode`. See [/order error codes](#order-error-codes). |
 | `errorMessage` | Present when `transaction` is `""`. Human-readable description. Do not match on this string, it may be parameterised. |

--- a/ultra/add-fees-to-ultra.mdx
+++ b/ultra/add-fees-to-ultra.mdx
@@ -17,7 +17,7 @@ llmsDescription: "UNMAINTAINED: Four-step setup to add custom fees (50–255 bps
 
 The Jupiter Ultra Swap API allows you to add integrator fees to the orders.
 
-**Key points summary:** Fees require Referral Program accounts, Jupiter takes 20% of your integrator fees, Ultra decides which mint to take fees in (based on a priority list), you must create referralTokenAccount for each expected feeMint, and fees enforce routing to Iris only.
+**Key points summary:** Fees require Referral Program accounts, Jupiter takes 20% of your integrator fees, Ultra decides which mint to take fees in (based on a priority list), you must create referralTokenAccount for each expected feeMint, and fees enforce routing to Metis only.
 
 <AccordionGroup>
     <Accordion title="Requires specific Referral Program Accounts">
@@ -83,8 +83,8 @@ The Jupiter Ultra Swap API allows you to add integrator fees to the orders.
         | XYZ                                  | USDC    | No                            |
     </Accordion>
     
-    <Accordion title="Enforces routing to Iris and other DEX aggregator routes">
-        When integrator fees are being added, it defaults routing to Iris and other DEX aggregator routes.
+    <Accordion title="Enforces routing to Metis and other DEX aggregator routes">
+        When integrator fees are being added, it defaults routing to Metis and other DEX aggregator routes.
         
         JupiterZ does not support integrator fees currently.
     </Accordion>

--- a/ultra/add-payer.mdx
+++ b/ultra/add-payer.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Add Integrator Payer"
 description: "Pay network fees and rent on behalf of your users through the Ultra Swap API."
-llmsDescription: "UNMAINTAINED: Use the payer parameter to pay network fees and rent on behalf of users. Requires referralAccount and referralFee. Enforces Iris-only routing."
+llmsDescription: "UNMAINTAINED: Use the payer parameter to pay network fees and rent on behalf of users. Requires referralAccount and referralFee. Enforces Metis-only routing."
 ---
 
 
@@ -9,7 +9,7 @@ llmsDescription: "UNMAINTAINED: Use the payer parameter to pay network fees and 
 **Ultra Swap API** is no longer actively maintained and has been superseded by [Swap V2](/swap).
 </Warning>
 
-The `payer` parameter lets integrators cover all network fees and rent for their users, removing the gasless requirements (no minimum trade size, no SOL balance check). It must be used with `referralAccount` and `referralFee`, and enforces Iris-only routing. The integrator backend must co-sign the transaction before submitting to `/execute`.
+The `payer` parameter lets integrators cover all network fees and rent for their users, removing the gasless requirements (no minimum trade size, no SOL balance check). It must be used with `referralAccount` and `referralFee`, and enforces Metis-only routing. The integrator backend must co-sign the transaction before submitting to `/execute`.
 
 <Note>
     If you are unfamiliar with [Ultra Swap's Gasless Support mechanisms](/ultra/gasless), please refer to the doc.
@@ -25,7 +25,7 @@ The Jupiter Ultra Swap API allows you to pay for networks fees and rent on behal
 | **Integrator payer takes precedent**  | When the `payer` parameter is passed in, it **always** takes precedent over Ultra's Gasless Support mechanism.|
 | **No minimum trade size requirement** | It does not require a minimum trade size. |
 | **ATA rent handling**                 | **Temporary WSOL TA**: At the end of the swap, the WSOL TA will be closed and only the rent amount refunded to payer.<br/><br/>**Non-WSOL TA**: The TA will not be closed, since it is highly likely used for the output amount of the swap. However, [integrator may use `closeAuthority` to control the close authority of the TA, different rules may apply](#close-authority). |
-| **Enforces routing to Iris only**     | When the `payer` parameter is passed in, it will default routing to only Iris. |
+| **Enforces routing to Metis only**     | When the `payer` parameter is passed in, it will default routing to only Metis. |
 | **Requires backend signing**          | Integrator is required to proxy the request to their backend in order to sign the transaction (partially signed by user) before sending to `/execute`
 
 ## Payer

--- a/ultra/gasless.mdx
+++ b/ultra/gasless.mdx
@@ -38,7 +38,7 @@ Refer to [Payer](/ultra/add-payer) section for more details and usage on the Int
 <Tabs>
     <Tab title="Jupiter Ultra Gasless Support">
         1. **When does it apply?**
-            * Gasless Support only kicks in for Iris router.
+            * Gasless Support only kicks in for Metis router.
             * Requires taker to have less than 0.01 SOL.
             * Minimum trade size of 10 USD is required, but this is dynamic as priority fees/tips can vary based on the current market conditions.
 
@@ -87,7 +87,7 @@ Refer to [Payer](/ultra/add-payer) section for more details and usage on the Int
         1. **When does it apply?**
             * Integrator Gas Payer works only when integrator passes in `referralAccount` and `referralFee`, together with `payer` and `closeAuthority`.
             * Regardless of how much SOL the taker has, the payer will be the fee payer.
-            * Applying these parameters will default routing to only Iris.
+            * Applying these parameters will default routing to only Metis.
 
         2. **What does it cover?**
             * The `payer` address will be the fee payer of the entire transaction:
@@ -105,7 +105,7 @@ Refer to [Payer](/ultra/add-payer) section for more details and usage on the Int
             * It adds a secondary signer to the transaction to pay to be the gas payer - which is the integrator.
 
         4. **What are the limitations?**
-            * Passing in `payer` parameters will default routing to only Iris.
+            * Passing in `payer` parameters will default routing to only Metis.
 
         ![Integrator Gas Payer Mechanism](/static/images/integrator-gas-payer-mechanism.png)
     </Tab>

--- a/ultra/index.mdx
+++ b/ultra/index.mdx
@@ -33,7 +33,7 @@ Key features at a glance: Juno liquidity engine (multi-source aggregation with s
 
 <AccordionGroup>
 <Accordion title="Juno Liquidity Engine">
-Ultra Swap utilizes the latest [Juno Liquidity Engine](/swap#routing-engines) which aggregates across multiple liquidity sources, including Jupiter's proprietary routing engines: improved versions of Iris and JupiterZ, and third-party liquidity sources, for the best possible price.
+Ultra Swap utilizes the latest [Juno Liquidity Engine](/swap#routing-engines) which aggregates across multiple liquidity sources, including Jupiter's proprietary routing engines: improved versions of Metis and JupiterZ, and third-party liquidity sources, for the best possible price.
 
 It also includes self-learning capabilities (to detect and sideline low-quality liquidity sources) which creates a competitive environment for all liquidity sources to continously optimize their performance and price.
 </Accordion>
@@ -90,7 +90,7 @@ Ultra Swap provides different gasless mechanisms for different scenarios.
 | Endpoint    | Description                                                                                           | Latency (P50 Average)   |
 | :----------- | :----------------------------------------------------------------------------------------------------- | :----------------------- |
 | `/order`    | Aggregating across multiple liquidity sources and selecting the best price.                           | 300ms                   |
-| `/execute`  | Broadcasting the transaction to the network and polling for the status and result of the transaction. | Roundtrip<br/>Iris: 700ms; JupiterZ: 2s |
+| `/execute`  | Broadcasting the transaction to the network and polling for the status and result of the transaction. | Roundtrip<br/>Metis: 700ms; JupiterZ: 2s |
 | `/holdings` | Retrieving the user's balances.                                                                       | 70ms                   |
 | `/shield`   | Enhanced token security feature to provide critical token information.                                | 150ms                   |
 | `/search`   | Searching for a token by its symbol, name or mint address.                                            | 15ms                   |
@@ -150,10 +150,10 @@ The following table provides a comprehensive comparison between Ultra Swap API a
 | | **Configuration Philosophy** | Optimized defaults refined by millions of swaps | Complete flexibility to build your own strategies |
 | | **Primary Use Case** | Teams wanting immediate, optimized swap execution | Teams needing CPI, custom instructions, or infrastructure control |
 | | **Complexity** | Opinionated, streamlined integration | Flexible, requires extensive custom development |
-| **Routing** | **Routing Engine** | Meta-aggregator combining:<br/>• Iris (enhanced Metis with self-learning)<br/>• DFlow<br/>• OKX<br/>• JupiterZ (RFQ with 20+ market makers) | Single, proven routing engine for on-chain liquidity |
+| **Routing** | **Routing Engine** | Meta-aggregator combining:<br/>• Metis (onchain routing with self-learning)<br/>• DFlow<br/>• OKX<br/>• JupiterZ (RFQ with 20+ market makers) | Single, proven routing engine for on-chain liquidity |
 | | **RFQ Access** | Built-in JupiterZ RFQ with 20+ market makers | Not supported |
 | | **Liquidity Sources** | Aggregates across multiple DEXes, PropAMMs, RFQ's MMs | Direct access to Solana's on-chain liquidity |
-| | **Iris Features** | • Ultra Signaling for tighter PropAMM quotes<br/>• Predictive Execution<br/>• Just-In-Time Market Revival<br/>• Self-learning route optimization<br/>• And more | Not applicable |
+| | **Metis Features** | • Ultra Signaling for tighter PropAMM quotes<br/>• Predictive Execution<br/>• Just-In-Time Market Revival<br/>• Self-learning route optimization<br/>• And more | Not applicable |
 | | **Continuous Improvement** | Automatic improvements deployed from millions of swaps | Stable routing engine, you build improvements |
 | **Execution** | **Transaction Flow** | Get order → Sign → Submit to execute endpoint | Get quote → Build transaction → Send via your infrastructure |
 | | **Transaction Sending** | Jupiter Beam proprietary engine with network of transaction senders | You build and maintain your own RPC pipeline |
@@ -166,9 +166,9 @@ The following table provides a comprehensive comparison between Ultra Swap API a
 | **Configuration** | **Slippage Optimization** | RTSE (Real-Time Slippage Estimator) applying heuristics and real-time adjustments using token categories, historical and real-time data | Manual configuration based on your strategy |
 | | **Priority Fee Management** | Automatic estimation and optimization using quality RPC and network data | You build custom fee estimation logic |
 | | **Manual Mode** | Available for user-facing trading experiences<br/>*Not recommended as default integration* | Full manual control always |
-| **Gasless** | **Ultra Gasless Support (Iris)** | Automatic when user has trade value but insufficient SOL<br/>Jupiter pays: tx fee, priority fee, token account rent | Not supported |
+| **Gasless** | **Ultra Gasless Support (Metis)** | Automatic when user has trade value but insufficient SOL<br/>Jupiter pays: tx fee, priority fee, token account rent | Not supported |
 | | **JupiterZ Gasless** | Market makers cover tx and priority fees<br/>Jupiter's gas wallet pays the rent to create the taker's output token account if needed | Not applicable |
-| | **Integrator as Payer** | Supported (Iris quotes only, all gas covered) | Supported with full control over implementation |
+| | **Integrator as Payer** | Supported (Metis quotes only, all gas covered) | Supported with full control over implementation |
 | **Customization** | **Transaction Customization** | Opinionated—no custom instructions, no CPI, no instruction modification | Full flexibility—add instructions, use for CPI, compose as needed |
 | **Operations** | **Customer Support** | Jupiter provides direct support to your users via official channels | Minimal technical support—you handle user-facing support |
 | | **Rate Limits** | Dynamic based on executed volume<br/>Base quota can be increased on request | Fixed tiers via [Portal](https://developers.jup.ag/portal), no overages |

--- a/ultra/response.mdx
+++ b/ultra/response.mdx
@@ -14,7 +14,7 @@ llmsDescription: "UNMAINTAINED: Ultra Swap API response schemas and error codes 
 <Tabs>
     <Tab title="Success" icon="face-smile">
         <CodeGroup>
-            ```json Iris
+            ```json Metis
             {
                 "mode": "ultra",
                 "inAmount": "100000000",
@@ -50,7 +50,7 @@ llmsDescription: "UNMAINTAINED: Ultra Swap API response schemas and error codes 
                 "inputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
                 "outputMint": "So11111111111111111111111111111111111111112",
                 "swapType": "aggregator",
-                "router": "iris",
+                "router": "metis",
                 "requestId": "019974a8-5fbb-7395-9355-9ebf8f844884",
                 "inUsdValue": 99.96761068334662,
                 "outUsdValue": 99.95449893632635,
@@ -186,7 +186,7 @@ In cases where a quote is available but the swap simulation fails, there are err
         }
         ```
 
-        In cases where the routes are of aggregator types like Iris and has been submitted to the network, but failed to land due to program related errors, the response will be as follows.
+        In cases where the routes are of aggregator types like Metis and has been submitted to the network, but failed to land due to program related errors, the response will be as follows.
 
         Only Jupiter V6 Aggregator Program Codes are parsed with description, for other DEX program codes, the error message can be `custom program error: #<code>`.
 


### PR DESCRIPTION
## Summary

The API returns `router: "metis"` (not `"iris"`) since ultra-api PR #1424 (May 2026). All documentation still referenced "iris" as the router value. This PR updates every occurrence across docs, OpenAPI specs, guides, and the style guide.

## Changes

- **API values**: `iris` → `metis` in all `router` enums, type annotations, parameter docs, and response examples
- **Product name**: "Iris" → "Metis" in prose (gasless support, routing engine descriptions, comparison tables)
- **Style guide**: Updated terminology table to mark "Iris" as legacy
- **llms.txt**: Regenerated

10 files changed, 36 substitutions. No path changes, no navigation changes.

## Checklist
- [x] `node generate-llms-from-docs.js` run
- [x] All pages have `title`, `description`, `llmsDescription`
- [x] `docs.json` navigation unchanged
- [x] `.claude/rules/style-guide.md` updated
