### PR TITLE
fix(prediction): align docs and OpenAPI with the live API

### DIFF
--- a/api-reference/prediction/follow-user.mdx
+++ b/api-reference/prediction/follow-user.mdx
@@ -1,5 +1,0 @@
----
-openapi: /openapi-spec/prediction/prediction.yaml post /follow/{ownerPubkey}
-title: "Follow User"
-description: "Follow a user to track their predictions"
----

--- a/api-reference/prediction/get-event-score.mdx
+++ b/api-reference/prediction/get-event-score.mdx
@@ -1,0 +1,5 @@
+---
+openapi: /openapi-spec/prediction/prediction.yaml get /events/{eventId}/score
+title: "Get Event Score"
+description: "Get the latest live score for a single event"
+---

--- a/api-reference/prediction/get-event-scores.mdx
+++ b/api-reference/prediction/get-event-scores.mdx
@@ -1,0 +1,5 @@
+---
+openapi: /openapi-spec/prediction/prediction.yaml get /events/scores
+title: "Get Live Scores"
+description: "Get the latest live scores for a set of events"
+---

--- a/api-reference/prediction/get-followers.mdx
+++ b/api-reference/prediction/get-followers.mdx
@@ -1,5 +1,0 @@
----
-openapi: /openapi-spec/prediction/prediction.yaml get /followers/{ownerPubkey}
-title: "Get Followers"
-description: "Get list of followers for a user"
----

--- a/api-reference/prediction/get-following.mdx
+++ b/api-reference/prediction/get-following.mdx
@@ -1,5 +1,0 @@
----
-openapi: /openapi-spec/prediction/prediction.yaml get /following/{ownerPubkey}
-title: "Get Following"
-description: "Get list of users being followed"
----

--- a/api-reference/prediction/unfollow-user.mdx
+++ b/api-reference/prediction/unfollow-user.mdx
@@ -1,5 +1,0 @@
----
-openapi: /openapi-spec/prediction/prediction.yaml delete /unfollow/{ownerPubkey}
-title: "Unfollow User"
-description: "Unfollow a previously followed user"
----

--- a/docs.json
+++ b/docs.json
@@ -421,7 +421,9 @@
                       "api-reference/prediction/get-events",
                       "api-reference/prediction/search-events",
                       "api-reference/prediction/get-event",
-                      "api-reference/prediction/get-suggested-events"
+                      "api-reference/prediction/get-suggested-events",
+                      "api-reference/prediction/get-event-scores",
+                      "api-reference/prediction/get-event-score"
                     ]
                   },
                   {

--- a/llms.txt
+++ b/llms.txt
@@ -308,13 +308,13 @@ Binary prediction markets for real-world events.
 - [About Prediction](https://developers.jup.ag/docs/prediction/index.md): Overview of Jupiter Prediction Market
 - [Events & Markets](https://developers.jup.ag/docs/prediction/events-and-markets.md): GET /events lists events with filters. GET /events/search searches by keyword. GET /markets/{marketId} returns market details with pricing in micro USD. GET /orderbook/{marketId} provides bid/ask depth.
 - [Open Positions](https://developers.jup.ag/docs/prediction/open-positions.md): POST /orders creates buy orders for YES/NO contracts. Required parameters: ownerPubkey, marketId, isYes, isBuy. Returns base64 transaction to sign and submit to Solana.
-- [Manage Positions](https://developers.jup.ag/docs/prediction/manage-positions.md): GET /positions lists holdings with P&L. DELETE /positions/{positionPubkey} closes entire position. POST /orders with isBuy=false sells partial. DELETE /orders cancels pending orders.
+- [Manage Positions](https://developers.jup.ag/docs/prediction/manage-positions.md): GET /positions lists holdings with P&L. GET /orders lists your orders. DELETE /positions/{positionPubkey} closes a single position. DELETE /positions closes all open positions and requires minSellPriceSlippageBps.
 - [Claim Payouts](https://developers.jup.ag/docs/prediction/claim-payouts.md): POST /positions/{positionPubkey}/claim creates payout transaction for winning positions. Check position.claimable=true to verify eligibility. No claim fees - winning contracts pay $1 each.
 
 ### Data & Analytics
 
 - [Position Data & History](https://developers.jup.ag/docs/prediction/position-data.md): GET /positions returns holdings with P&L. GET /orders lists orders with fill status. GET /history provides transaction history with event types: order_created, order_filled, order_failed, position_updated, position_lost, payout_claimed.
-- [Social Features](https://developers.jup.ag/docs/prediction/social-features.md): GET /profiles/{pubkey} returns user stats. POST /follow and DELETE /unfollow manage relationships. GET /leaderboards returns rankings by pnl/volume/win_rate. GET /trades provides global trade feed.
+- [Social Features](https://developers.jup.ag/docs/prediction/social-features.md): GET /profiles/{pubkey} returns user stats. GET /profiles/{pubkey}/pnl-history returns time-series P&L. GET /leaderboards returns rankings by pnl/volume/win_rate. GET /trades provides the global trade feed.
 
 ### Guides
 

--- a/llms.txt
+++ b/llms.txt
@@ -328,6 +328,8 @@ Binary prediction markets for real-world events.
 - [Search Events](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml): Search for events by title or keyword
 - [Get Event](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml): Get detailed information about a specific event
 - [Get Suggested Events](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml): Get personalized event suggestions based on user activity
+- [Get Live Scores](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml): Get the latest live scores for a set of events
+- [Get Event Score](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml): Get the latest live score for a single event
 
 #### Markets
 

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -50,6 +50,21 @@ components:
           format: uri
         isLive:
           type: boolean
+        isActive:
+          type: boolean
+        category:
+          type: string
+        subcategory:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        beginAt:
+          type: string
+          nullable: true
+        closeCondition:
+          type: string
       required:
         - eventId
     MarketMetadata:
@@ -57,18 +72,36 @@ components:
       properties:
         marketId:
           type: string
+        eventId:
+          type: string
         title:
+          type: string
+        subtitle:
+          type: string
+        description:
+          type: string
+        provider:
           type: string
         status:
           type: string
         result:
           type: string
+          nullable: true
         closeTime:
           type: number
         openTime:
           type: number
         isTeamMarket:
           type: boolean
+        marketOptions:
+          type: array
+          items:
+            type: object
+            properties:
+              label:
+                type: string
+              buyYes:
+                type: boolean
         rulesPrimary:
           type: string
         rulesSecondary:
@@ -95,10 +128,24 @@ components:
           description: Trading volume for this market
     Market:
       type: object
+      description: Market fields are returned flat (there is no nested `metadata` object).
       properties:
         marketId:
           type: string
           description: Market identifier
+        eventId:
+          type: string
+          description: Parent event identifier
+        provider:
+          type: string
+          enum:
+            - polymarket
+            - gx
+            - bisonfi
+          description: Market data provider
+        title:
+          type: string
+          description: Market title
         status:
           type: string
           enum:
@@ -108,11 +155,11 @@ components:
           description: Current market status
         result:
           type: string
+          nullable: true
           enum:
-            - null
-            - yes
-            - no
-          description: Current market result
+            - "yes"
+            - "no"
+          description: Market result. null until resolved, then "yes" or "no"
         openTime:
           type: number
           description: Unix timestamp (seconds) when the market opens
@@ -120,9 +167,11 @@ components:
           type: number
           description: Unix timestamp (seconds) when the market closes
         resolveAt:
-          type: number
           nullable: true
-          description: Unix timestamp (seconds) when the market resolved (null if pending)
+          oneOf:
+            - type: string
+            - type: number
+          description: When the market resolved. null while open; returned as an ISO 8601 string once resolved
         marketResultPubkey:
           type: string
           nullable: true
@@ -132,8 +181,47 @@ components:
           nullable: true
           format: uri
           description: Market image URL
-        metadata:
-          $ref: "#/components/schemas/MarketMetadata"
+        rulesPrimary:
+          type: string
+          description: Primary resolution rules
+        rulesSecondary:
+          type: string
+          description: Secondary resolution rules
+        outcomes:
+          type: array
+          items:
+            type: string
+          description: Outcome labels for the market
+        marketOptions:
+          type: array
+          items:
+            type: object
+            properties:
+              label:
+                type: string
+              buyYes:
+                type: boolean
+          description: Selectable options for team or multi-outcome markets
+        clobTokenIds:
+          type: array
+          items:
+            type: string
+          description: Underlying CLOB token IDs (provider-specific)
+        isTeamMarket:
+          type: boolean
+          description: True for team or sports markets
+        team:
+          type: object
+          nullable: true
+          description: Team metadata, present for team markets
+        sportsLine:
+          type: number
+          nullable: true
+          description: Sports line or handicap, when applicable
+        sportsMarketType:
+          type: string
+          nullable: true
+          description: Sports market type, when applicable
         pricing:
           $ref: "#/components/schemas/MarketPricing"
       required:

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -738,7 +738,20 @@ components:
           description: True if this is a YES position
         contracts:
           type: string
-          description: Contracts held (u64 as string)
+          description: Legacy whole-contract quantity held. Use contractsMicro or contractsDecimal for the exact fractional quantity.
+        contractsMicro:
+          type: string
+          description: Contracts held in micro-contract units (u64 as string, 1000000 = 1 contract)
+        contractsDecimal:
+          type: string
+          description: Contracts held as a decimal string
+        source:
+          type: string
+          description: Origin of the position (e.g. "program")
+        maxSlippageBps:
+          type: integer
+          minimum: 0
+          description: Maximum slippage recorded for the position, in basis points
         totalCostUsd:
           type: string
           description: Total cost basis in micro USD (u128 as string)

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -487,6 +487,11 @@ components:
         externalOrderId:
           type: string
           nullable: true
+        requiredSigners:
+          type: array
+          items:
+            type: string
+          description: Public keys that must sign the returned transaction
         order:
           type: object
           properties:
@@ -518,10 +523,22 @@ components:
               description: True when the order is on the YES side
             contracts:
               type: string
-              description: Contracts included in this order
+              description: Legacy whole-contract quantity. Use contractsMicro or contractsDecimal for the exact fractional quantity.
+            contractsMicro:
+              type: string
+              description: Contracts in micro-contract units (u64 as string, 1000000 = 1 contract)
+            contractsDecimal:
+              type: string
+              description: Contracts as a decimal string
             newContracts:
               type: string
-              description: Position contracts after executing the order
+              description: Position contracts after executing the order (legacy whole-contract quantity)
+            newContractsMicro:
+              type: string
+              description: Position contracts after the order, in micro-contract units
+            newContractsDecimal:
+              type: string
+              description: Position contracts after the order, as a decimal string
             maxBuyPriceUsd:
               type: string
               nullable: true
@@ -555,6 +572,22 @@ components:
             estimatedTotalFeeUsd:
               type: string
               description: Estimated total fees applied (micro USD)
+            payoutUsd:
+              type: string
+              description: Position max payout for this order (micro USD)
+            slippageBps:
+              type: integer
+              minimum: 0
+              description: >-
+                Estimated slippage for this order, in basis points (0 = none, 250 = 2.5%).
+                For a Polymarket buy this is the estimated price impact from sweeping
+                orderbook levels; for a sell it is the max allowed slippage from best bid
+                to the protected sell floor. Treat it as a quote signal, not a guaranteed loss.
+            maxSlippageBps:
+              type: integer
+              minimum: 0
+              nullable: true
+              description: Maximum slippage allowed for this order, in basis points
           required:
             - orderPubkey
             - orderAtaPubkey

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -649,68 +649,6 @@ components:
           description: Mint address for the deposit token
       required:
         - isBuy
-    CloseOrderResponse:
-      type: object
-      properties:
-        blockhash:
-          type: string
-        transaction:
-          type: string
-          description: Base64 encoded transaction
-        latestBlockhash:
-          type: string
-        lastValidBlockHeight:
-          type: integer
-          minimum: 0
-        requiredSigners:
-          type: array
-          items:
-            type: string
-        computeUnits:
-          type: integer
-          minimum: 0
-        orderPubkey:
-          type: string
-        accounts:
-          type: object
-          properties:
-            owner:
-              type: string
-            authority:
-              type: string
-            vault:
-              type: string
-            marketId:
-              type: string
-            position:
-              type: string
-            order:
-              type: string
-            orderAta:
-              type: string
-            ownerTokenAccount:
-              type: string
-            settlementMint:
-              type: string
-          required:
-            - owner
-            - authority
-            - vault
-            - marketId
-            - position
-            - order
-            - orderAta
-            - ownerTokenAccount
-            - settlementMint
-      required:
-        - blockhash
-        - transaction
-        - latestBlockhash
-        - lastValidBlockHeight
-        - requiredSigners
-        - computeUnits
-        - orderPubkey
-        - accounts
     Position:
       type: object
       properties:
@@ -962,6 +900,11 @@ components:
           type: string
           minLength: 32
           description: Position owner public key
+        minSellPriceSlippageBps:
+          type: number
+          description: Slippage tolerance applied to each sell, in basis points. Required.
+      required:
+        - minSellPriceSlippageBps
     ClaimPositionRequest:
       type: object
       properties:

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -1248,6 +1248,12 @@ paths:
           name: includeMarkets
           in: query
         - schema:
+            type: boolean
+          required: false
+          description: Include all allowed sports market types (moneyline, spread, totals) and extra (e.g. Saba) markets mapped onto Polymarket events. Defaults to false (moneyline only). F1 events always include every sportsMarketType.
+          name: includeAllMarkets
+          in: query
+        - schema:
             type: integer
             nullable: true
             minimum: 0
@@ -1369,6 +1375,12 @@ paths:
             nullable: true
           required: false
           name: includeMarkets
+          in: query
+        - schema:
+            type: boolean
+          required: false
+          description: Include all allowed sports market types (moneyline, spread, totals) and extra (e.g. Saba) markets mapped onto Polymarket events. Defaults to false (moneyline only). F1 events always include every sportsMarketType.
+          name: includeAllMarkets
           in: query
       responses:
         "200":

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -1159,6 +1159,8 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Event"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
                 required:
                   - data
   /events:
@@ -1251,14 +1253,24 @@ paths:
               - new
               - live
               - trending
+              - upcoming
             description: Apply named filters. Use `new` for events created in the last 24
-              hours, `live` for events that have begun, and `trending` for
-              events with recent trade activity.
+              hours, `live` for events that have begun, `trending` for events
+              with recent trade activity, and `upcoming` for events that have not
+              begun yet.
           required: false
           description: Apply named filters. Use `new` for events created in the last 24
-            hours, `live` for events that have begun, and `trending` for events
-            with recent trade activity.
+            hours, `live` for events that have begun, `trending` for events
+            with recent trade activity, and `upcoming` for events that have not
+            begun yet.
           name: filter
+          in: query
+        - schema:
+            type: string
+            description: Filter events by tag (e.g. `soccer`).
+          required: false
+          description: Filter events by tag (e.g. `soccer`).
+          name: tags
           in: query
       responses:
         "200":
@@ -1942,16 +1954,47 @@ paths:
     get:
       tags:
         - Forecast
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          description: Market identifier to fetch the forecast for. Required; omitting it returns 400.
+          name: marketId
+          in: query
       responses:
         "200":
-          description: Forecast data from price service
+          description: Forecast time-series for the market
           content:
             application/json:
               schema:
                 type: object
-                nullable: true
-                description: Forecast response payload. Shape varies by provider; common fields listed below.
-                additionalProperties: true
+                properties:
+                  forecast_history:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        market_ticker:
+                          type: string
+                        event_ticker:
+                          type: string
+                        end_period_ts:
+                          type: number
+                        period_interval:
+                          type: number
+                        numerical_forecast:
+                          type: number
+                        raw_numerical_forecast:
+                          type: number
+                        formatted_forecast:
+                          type: string
+        "400":
+          description: Invalid or missing market ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "502":
           description: Failed to fetch forecast data
           content:
@@ -1964,7 +2007,7 @@ paths:
         - Trading
       responses:
         "200":
-          description: Current Kalshi and Polymarket exchange trading status
+          description: Whether trading is currently enabled
           content:
             application/json:
               schema:
@@ -1994,7 +2037,7 @@ paths:
                 properties:
                   yes:
                     type: array
-                    description: YES-side levels sorted by price descending. Each entry is a [price_cents, size] tuple.
+                    description: YES-side levels sorted by price ascending. Each entry is a [price_cents, size] tuple. price_cents is rounded, so sub-cent levels show 0; size may be fractional.
                     items:
                       type: array
                       items:
@@ -2003,7 +2046,7 @@ paths:
                       maxItems: 2
                   no:
                     type: array
-                    description: NO-side levels sorted by price descending. Each entry is a [price_cents, size] tuple.
+                    description: NO-side levels sorted by price ascending. Each entry is a [price_cents, size] tuple. price_cents is rounded, so sub-cent levels show 0; size may be fractional.
                     items:
                       type: array
                       items:
@@ -2067,6 +2110,13 @@ paths:
                     type: string
                   totalActiveContracts:
                     type: string
+                    description: Legacy whole-contract count. Use totalActiveContractsMicro or totalActiveContractsDecimal for the exact value.
+                  totalActiveContractsMicro:
+                    type: string
+                    description: Active contracts in micro-contract units (1000000 = 1 contract)
+                  totalActiveContractsDecimal:
+                    type: string
+                    description: Active contracts as a decimal string
                   totalPositionsValueUsd:
                     type: string
                 required:
@@ -2161,7 +2211,8 @@ paths:
                       type: object
                       properties:
                         id:
-                          type: number
+                          type: string
+                          description: Trade identifier (e.g. "order-1906029")
                         ownerPubkey:
                           type: string
                         marketId:
@@ -2178,8 +2229,8 @@ paths:
                         side:
                           type: string
                           enum:
-                            - yes
-                            - no
+                            - "yes"
+                            - "no"
                         eventTitle:
                           type: string
                         marketTitle:
@@ -2192,6 +2243,17 @@ paths:
                           type: string
                         eventId:
                           type: string
+                        isTeamMarket:
+                          type: boolean
+                        marketOptions:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              label:
+                                type: string
+                              buyYes:
+                                type: boolean
                       required:
                         - id
                         - ownerPubkey

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -877,7 +877,13 @@ components:
               type: boolean
             contracts:
               type: string
-              description: Contracts settled (u64 as string)
+              description: Legacy whole-contract quantity settled. Use contractsMicro or contractsDecimal for the exact fractional quantity.
+            contractsMicro:
+              type: string
+              description: Contracts settled in micro-contract units (u64 as string, 1000000 = 1 contract)
+            contractsDecimal:
+              type: string
+              description: Contracts settled as a decimal string
             payoutAmountUsd:
               type: string
               description: Payout amount in micro USD (u64 as string)
@@ -924,10 +930,11 @@ components:
             - order_created
             - order_filled
             - order_failed
+            - order_closed
             - payout_claimed
             - position_updated
             - position_lost
-          description: Type of history event
+          description: Type of history event. Position wins surface as payout_claimed (there is no position_won).
         signature:
           type: string
           description: Solana transaction signature
@@ -966,13 +973,31 @@ components:
           description: True when the event relates to the YES side
         contracts:
           type: string
-          description: Number of contracts in the order (u64 as string)
+          description: Number of contracts in the order. Legacy whole-contract value; see contractsMicro/contractsDecimal for the exact quantity.
+        contractsMicro:
+          type: string
+          description: Contracts in micro-contract units (u64 as string, 1000000 = 1 contract)
+        contractsDecimal:
+          type: string
+          description: Contracts as a decimal string
         filledContracts:
           type: string
-          description: Number of contracts filled (u64 as string)
+          description: Number of contracts filled (legacy whole-contract value)
+        filledContractsMicro:
+          type: string
+          description: Filled contracts in micro-contract units
+        filledContractsDecimal:
+          type: string
+          description: Filled contracts as a decimal string
         contractsSettled:
           type: string
-          description: Number of contracts settled in this event (u64 as string)
+          description: Number of contracts settled in this event (legacy whole-contract value)
+        contractsSettledMicro:
+          type: string
+          description: Settled contracts in micro-contract units
+        contractsSettledDecimal:
+          type: string
+          description: Settled contracts as a decimal string
         maxFillPriceUsd:
           type: string
           description: Maximum fill price in micro USD (u64 as string)

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -1113,6 +1113,58 @@ components:
           type: boolean
       required:
         - trading_active
+    GameScore:
+      type: object
+      properties:
+        eventId:
+          type: string
+          description: Application-level event identifier
+        gameId:
+          type: string
+        leagueAbbreviation:
+          type: string
+          nullable: true
+        homeTeam:
+          type: string
+          nullable: true
+        awayTeam:
+          type: string
+          nullable: true
+        score:
+          type: string
+          nullable: true
+          description: Raw score string from the provider (e.g. "2-0")
+        period:
+          type: string
+          nullable: true
+          description: Current period (e.g. "2H")
+        elapsed:
+          type: string
+          nullable: true
+          description: Elapsed time within the game (e.g. "90")
+        status:
+          type: string
+          nullable: true
+          description: Provider status string (e.g. "InProgress")
+        live:
+          type: boolean
+          description: True while the game is in progress
+        ended:
+          type: boolean
+          description: True once the game has finished
+        finishedTimestamp:
+          type: string
+          nullable: true
+          description: ISO 8601 timestamp when the game finished, if ended
+        updatedAt:
+          type: string
+          description: ISO 8601 timestamp of the last score update
+      required:
+        - eventId
+        - gameId
+        - live
+        - ended
+        - updatedAt
   parameters: {}
 paths:
   /events/search:
@@ -1359,6 +1411,52 @@ paths:
                       $ref: "#/components/schemas/Event"
                 required:
                   - data
+  /events/scores:
+    get:
+      tags:
+        - Events
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            example: POLY-351731,POLY-30615
+          required: true
+          description: Comma-separated event IDs to fetch live scores for (max 100)
+          name: eventIds
+          in: query
+      responses:
+        "200":
+          description: Latest live scores for the given event IDs. Events without a score row are omitted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/GameScore"
+                required:
+                  - data
+  /events/{eventId}/score:
+    get:
+      tags:
+        - Events
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          description: Event identifier
+          name: eventId
+          in: path
+      responses:
+        "200":
+          description: Latest live score for the event, or null if no score row exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GameScore"
   /events/{eventId}/markets:
     get:
       tags:

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -742,9 +742,6 @@ components:
         feesPaidUsd:
           type: string
           description: Total fees paid in micro USD (u64 as string)
-        integratorFeeUsd:
-          type: string
-          description: Integrator fee in micro USD (u64 as string)
         realizedPnlUsd:
           type: number
           description: Realized PnL in micro USD (i64 as number)

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -50,21 +50,6 @@ components:
           format: uri
         isLive:
           type: boolean
-        isActive:
-          type: boolean
-        category:
-          type: string
-        subcategory:
-          type: string
-        tags:
-          type: array
-          items:
-            type: string
-        beginAt:
-          type: string
-          nullable: true
-        closeCondition:
-          type: string
       required:
         - eventId
     MarketMetadata:
@@ -263,7 +248,13 @@ components:
             $ref: "#/components/schemas/Market"
         volumeUsd:
           type: string
-          description: Total volume for the event
+          description: Total volume for the event in micro USD
+        volume24hr:
+          type: string
+          description: Rolling 24-hour volume in micro USD
+        liveScore:
+          nullable: true
+          description: Live score data for sports events; null when no score is available
         closeCondition:
           type: string
           description: Close condition for the event
@@ -751,6 +742,9 @@ components:
         feesPaidUsd:
           type: string
           description: Total fees paid in micro USD (u64 as string)
+        integratorFeeUsd:
+          type: string
+          description: Integrator fee in micro USD (u64 as string)
         realizedPnlUsd:
           type: number
           description: Realized PnL in micro USD (i64 as number)

--- a/openapi-spec/prediction/prediction.yaml
+++ b/openapi-spec/prediction/prediction.yaml
@@ -636,7 +636,17 @@ components:
           anyOf:
             - type: string
             - type: number
-          description: Number of contracts to sell (only applicable when `isBuy` is `false`)
+          description: Legacy whole-contract sell quantity (only when `isBuy` is `false`). Cannot express fractions; prefer contractsMicro or contractsDecimal. Provide only one of contracts, contractsMicro, or contractsDecimal.
+        contractsMicro:
+          anyOf:
+            - type: string
+            - type: number
+          description: Exact sell quantity in micro-contract units (1000000 = 1 contract). Provide only one of contracts, contractsMicro, or contractsDecimal.
+        contractsDecimal:
+          anyOf:
+            - type: string
+            - type: number
+          description: Exact sell quantity as a decimal (e.g. 5.777773). Provide only one of contracts, contractsMicro, or contractsDecimal.
         depositAmount:
           anyOf:
             - type: string

--- a/prediction/claim-payouts.mdx
+++ b/prediction/claim-payouts.mdx
@@ -36,16 +36,16 @@ When a market closes, it goes through a settlement process:
 | State | Description |
 |:------|:------------|
 | `open` | Market actively trading |
-| `closed` | Trading stopped, awaiting result determination |
-| `settled` | Result determined, payouts available |
+| `closed` | Trading stopped; awaiting or holding the result |
 | `cancelled` | Market voided, positions refunded |
+
+A resolved market stays `closed` with its `result` set; there is no separate `settled` status.
 
 ### Market Results
 
 | Result | Description |
 |:-------|:------------|
-| `""` (empty) | Not yet resolved |
-| `pending` | Resolution in progress |
+| `null` | Not yet resolved |
 | `yes` | YES outcome confirmed |
 | `no` | NO outcome confirmed |
 
@@ -141,7 +141,11 @@ A position is claimable when:
 
 ## Claiming a Payout
 
-Use `POST /positions/{positionPubkey}/claim` to create a claim transaction.
+Use `POST /positions/{positionPubkey}/claim` to create a claim transaction. Calling it before the market resolves returns `400 Market not settled yet`.
+
+<Note>
+Some markets settle automatically and do not need a claim. For those positions the endpoint returns a message saying no claim is required. Combined with the 24-hour auto-claim, you can always rely on winnings being credited without a manual claim.
+</Note>
 
 ```js
 const positionPubkey = 'position-pubkey-789';
@@ -169,13 +173,20 @@ Example response:
 ```json expandable
 {
   "transaction": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAGDkS+3LuGTbs...",
-  "position": {
-    "pubkey": "position-pubkey-789",
-    "contracts": "10",
-    "payoutAmountUsd": "10000000"
+  "txMeta": {
+    "blockhash": "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N",
+    "lastValidBlockHeight": 279632475
   },
-  "blockhash": "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N",
-  "lastValidBlockHeight": 279632475
+  "position": {
+    "positionPubkey": "position-pubkey-789",
+    "marketPubkey": "market-pubkey-456",
+    "userPubkey": "your-wallet-pubkey",
+    "isYes": true,
+    "contracts": "10",
+    "contractsMicro": "10000000",
+    "contractsDecimal": "10",
+    "payoutAmountUsd": "10000000"
+  }
 }
 ```
 

--- a/prediction/events-and-markets.mdx
+++ b/prediction/events-and-markets.mdx
@@ -292,6 +292,62 @@ const orderbook = await response.json();
 
 ---
 
+## Get Live Scores
+
+For sports events, use `GET /events/scores` to fetch live scores for one or more events, or `GET /events/{eventId}/score` for a single event. Events without a score row are omitted from the list response.
+
+```js
+const response = await fetch(
+  'https://api.jup.ag/prediction/v1/events/scores?' + new URLSearchParams({
+    eventIds: 'POLY-351731,POLY-30615' // comma-separated, max 100
+  }),
+  {
+    headers: {
+      'x-api-key': 'your-api-key'
+    }
+  }
+);
+
+const { data } = await response.json();
+```
+
+Example response:
+
+```json expandable
+{
+  "data": [
+    {
+      "eventId": "POLY-351731",
+      "gameId": "90086923",
+      "leagueAbbreviation": "fifwc",
+      "homeTeam": "France",
+      "awayTeam": "Senegal",
+      "score": "2-0",
+      "period": "2H",
+      "elapsed": "90",
+      "status": "InProgress",
+      "live": true,
+      "ended": false,
+      "finishedTimestamp": null,
+      "updatedAt": "2026-06-16T20:53:39.834Z"
+    }
+  ]
+}
+```
+
+| Field | Description |
+|:------|:------------|
+| `score` | Raw score string from the provider (e.g. `"2-0"`) |
+| `period` | Current period (e.g. `"2H"`) |
+| `elapsed` | Elapsed time within the game (e.g. `"90"`) |
+| `status` | Provider status string (e.g. `"InProgress"`) |
+| `live` | `true` while the game is in progress |
+| `ended` | `true` once the game has finished |
+| `finishedTimestamp` | ISO 8601 timestamp when the game finished, if ended |
+| `updatedAt` | ISO 8601 timestamp of the last score update |
+
+---
+
 ## Check Trading Status
 
 Use `GET /trading-status` to verify if the exchange is actively trading. This is useful for conditional logic before placing orders.

--- a/prediction/events-and-markets.mdx
+++ b/prediction/events-and-markets.mdx
@@ -35,10 +35,12 @@ Use `GET /events` to retrieve a paginated list of prediction market events. You 
 |:----------|:-----|:------------|
 | `category` | string | Filter by category: `crypto`, `sports`, `politics`, `esports`, `culture`, `economics`, `tech` |
 | `subcategory` | string | Filter by subcategory within the category |
-| `filter` | string | Filter by status: `new`, `live`, `trending` |
+| `tags` | string | Filter by tag (e.g. `soccer`) |
+| `filter` | string | Filter by status: `new`, `live`, `trending`, `upcoming` |
 | `sortBy` | string | Sort field |
 | `sortDirection` | string | Sort direction: `asc` or `desc` |
 | `includeMarkets` | boolean | Include nested markets in response |
+| `includeAllMarkets` | boolean | Include all sports market types (moneyline, spread, totals) and Saba markets. Defaults to `false` (moneyline only); F1 events always include every type |
 | `start` | number | Pagination start index |
 | `end` | number | Pagination end index |
 

--- a/prediction/events-and-markets.mdx
+++ b/prediction/events-and-markets.mdx
@@ -159,22 +159,20 @@ Example response:
 ```json expandable
 {
   "marketId": "market-456",
+  "eventId": "event-123",
+  "provider": "polymarket",
+  "title": "SOL $500 by Q2 2026",
   "status": "open",
   "result": null,
   "openTime": 1704067200,
   "closeTime": 1719792000,
   "resolveAt": null,
   "marketResultPubkey": null,
-  "metadata": {
-    "marketId": "market-456",
-    "title": "SOL $500 by Q2 2026",
-    "status": "open",
-    "result": "",
-    "closeTime": 1719792000,
-    "openTime": 1704067200,
-    "isTeamMarket": false,
-    "rulesPrimary": "Resolves YES if SOL reaches $500..."
-  },
+  "imageUrl": null,
+  "rulesPrimary": "Resolves YES if SOL reaches $500...",
+  "rulesSecondary": "",
+  "outcomes": ["Yes", "No"],
+  "isTeamMarket": false,
   "pricing": {
     "buyYesPriceUsd": 650000,
     "buyNoPriceUsd": 380000,
@@ -184,6 +182,8 @@ Example response:
   }
 }
 ```
+
+Market fields are returned flat. There is no nested `metadata` object. `resolveAt` stays `null` while the market is open and becomes an ISO 8601 string once it resolves.
 
 ### Understanding Prices
 
@@ -226,8 +226,7 @@ Market prices reflect the implied probability of an outcome. A `buyYesPriceUsd` 
 
 | Result | Description |
 |:-------|:------------|
-| `""` (empty) | Market not yet resolved |
-| `pending` | Resolution in progress |
+| `null` | Market not yet resolved |
 | `yes` | YES outcome confirmed |
 | `no` | NO outcome confirmed |
 
@@ -241,12 +240,12 @@ The response has four arrays. Each entry is a `[price, quantity]` pair:
 
 | Field | Description |
 |:------|:------------|
-| `yes` | YES bids: `[price_cents, quantity]`. Price is in cents (e.g. `1` = $0.01). |
+| `yes` | YES bids: `[price_cents, quantity]`. Price is in cents (e.g. `1` = $0.01). `price_cents` is rounded, so sub-cent levels show `0`; use `yes_dollars` for the exact price. |
 | `no` | NO bids: `[price_cents, quantity]`. Same format as `yes`. |
 | `yes_dollars` | YES bids with price as decimal string: `["0.0100", quantity]`. |
 | `no_dollars` | NO bids with price as decimal string. Same format as `yes_dollars`. |
 
-Quantities are in base units (e.g. contract size). Arrays are ordered by price (typically best bid first).
+Arrays are sorted by price ascending. Quantities are in base units and may be fractional.
 
 Example: Get orderbook data for a specific market
 

--- a/prediction/index.mdx
+++ b/prediction/index.mdx
@@ -220,7 +220,21 @@ Each contract represents a claim to **$1 if correct**:
 - If you buy NO at 40¢ and NO wins, you profit 60¢ per contract
 - Losing contracts expire worthless
 
-Contracts are fractional. The `contracts` field is the legacy whole-contract value; the API also returns `contractsMicro` (`1000000` = 1 contract) and `contractsDecimal` for the exact amount.
+### Fractional Contracts
+
+Contracts are fractional. Each response carries three forms of every contract quantity:
+
+- `*Micro` (e.g. `contractsMicro`) — exact amount in micro-contracts, where `1000000` = 1 contract. Use this for any math.
+- `*Decimal` (e.g. `contractsDecimal`) — exact amount as a decimal string (e.g. `"5.777773"`). Use this for display.
+- legacy whole-contract field (e.g. `contracts`) — the amount **floored to a whole number**. Kept for backwards compatibility only; fills can be fractional, so this value is truncated and must not be used for accounting.
+
+This applies across the API: `contracts`, `filledContracts`, `contractsSettled`, `newContracts`, and `totalActiveContracts` each have `*Micro` and `*Decimal` siblings.
+
+<Warning>
+`*Micro` values are returned as strings (`u64`/`u128`) and can exceed JavaScript's safe-integer range. Parse them with `BigInt` or a decimal library, never `parseFloat` or `Number`.
+</Warning>
+
+When creating an order you may send `contractsMicro` (or `contractsDecimal`, or the legacy `contracts`), but only one quantity field per request. Effective fill sizes are floored to 0.01-contract increments; you can submit finer sizes, but executed amounts round down to the nearest 0.01.
 
 ### Price as Probability
 

--- a/prediction/index.mdx
+++ b/prediction/index.mdx
@@ -220,6 +220,8 @@ Each contract represents a claim to **$1 if correct**:
 - If you buy NO at 40¢ and NO wins, you profit 60¢ per contract
 - Losing contracts expire worthless
 
+Contracts are fractional. The `contracts` field is the legacy whole-contract value; the API also returns `contractsMicro` (`1000000` = 1 contract) and `contractsDecimal` for the exact amount.
+
 ### Price as Probability
 
 Market prices reflect implied probability:

--- a/prediction/manage-positions.mdx
+++ b/prediction/manage-positions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Manage Positions"
-description: "View your prediction market positions, sell contracts to reduce exposure, and cancel pending orders."
-llmsDescription: "GET /positions lists holdings with P&L. DELETE /positions/{positionPubkey} closes entire position. POST /orders with isBuy=false sells partial. DELETE /orders cancels pending orders."
+description: "View your prediction market positions and sell contracts to close positions."
+llmsDescription: "GET /positions lists holdings with P&L. GET /orders lists your orders. DELETE /positions/{positionPubkey} closes a single position. DELETE /positions closes all open positions and requires minSellPriceSlippageBps."
 ---
 
 <Note>
@@ -111,6 +111,8 @@ const closeResponse = await response.json();
 
 Use `DELETE /positions` to close all your open positions at once. This is useful for quickly exiting all markets.
 
+`minSellPriceSlippageBps` is required (slippage tolerance per sell, in basis points). The request returns `{ data: [...] }`, one sell transaction per open position, each in the same shape as a single close.
+
 ```js
 const response = await fetch('https://api.jup.ag/prediction/v1/positions', {
   method: 'DELETE',
@@ -120,11 +122,12 @@ const response = await fetch('https://api.jup.ag/prediction/v1/positions', {
   },
   body: JSON.stringify({
     ownerPubkey: wallet.publicKey.toString(),
+    minSellPriceSlippageBps: 2500,
   })
 });
 
 const closeAllResponse = await response.json();
-// Sign and submit the transaction (see above)
+// Sign and submit each transaction in closeAllResponse.data (see above)
 ```
 
 ### Sign and Submit the Transaction

--- a/prediction/open-positions.mdx
+++ b/prediction/open-positions.mdx
@@ -42,7 +42,9 @@ Use `POST /orders` to create a buy order for YES or NO contracts.
 | `depositAmount` | string | Yes | Amount to deposit (in native token units of JupUSD or USDC) |
 | `depositMint` | string | Yes | Token mint for deposit (JupUSD or USDC) |
 
-Example: Create a buy order for 2 USD worth of contracts
+The minimum order is 5 USD (`5000000` native token units). Smaller deposits return `400 Minimum order is $5`.
+
+Example: Create a buy order for 5 USD worth of contracts
 ```js
 const response = await fetch('https://api.jup.ag/prediction/v1/orders', {
   method: 'POST',
@@ -52,7 +54,7 @@ const response = await fetch('https://api.jup.ag/prediction/v1/orders', {
   },
   body: JSON.stringify({
     ownerPubkey: wallet.publicKey.toString(),
-    depositAmount: '2000000',
+    depositAmount: '5000000',
     depositMint: 'JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD',
     marketId: marketId,
     isYes: true,
@@ -72,7 +74,8 @@ console.log(orderResponse);
 | `txMeta` | Transaction metadata: `blockhash` and `lastValidBlockHeight` |
 | `order.orderPubkey` | The order's on-chain account address |
 | `order.positionPubkey` | The position's on-chain account address |
-| `order.contracts` | The number of contracts being purchased |
+| `order.contracts` | Legacy whole-contract quantity. Contracts are fractional: use `order.contractsMicro` (`1000000` = 1 contract) or `order.contractsDecimal` for the exact amount |
+| `order.requiredSigners` | Public keys that must sign the transaction |
 
 
 ## Sign and Submit the Transaction
@@ -93,7 +96,7 @@ const orderResponse = await fetch('https://api.jup.ag/prediction/v1/orders', {
   },
   body: JSON.stringify({
     ownerPubkey: wallet.publicKey.toString(),
-    depositAmount: '2000000',
+    depositAmount: '5000000',
     depositMint: 'JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD',
     marketId: marketId, // Get from events and markets guide
     isYes: true,
@@ -158,9 +161,12 @@ Polling immediately after submitting the transaction might return a `pending` st
 
 | Status | Description |
 |:-------|:------------|
-| `pending` | Order submitted, waiting to be filled |
+| `created` | Order account created on-chain, waiting to be filled |
+| `partiallyfilled` | Order partially filled |
 | `filled` | Order fully executed |
 | `failed` | Order could not be filled |
+
+`GET /orders/{orderPubkey}` returns `400` once an order has filled and its account is closed; use `GET /orders/status/{orderPubkey}` or `GET /history` to track a completed order.
 
 ```js
 const orderPubkey = orderResponse.order.orderPubkey;

--- a/prediction/position-data.mdx
+++ b/prediction/position-data.mdx
@@ -59,7 +59,9 @@ Each position includes identity, state, and P&L fields. All USD values are in mi
 | `ownerPubkey` | string | Position owner wallet public key |
 | `marketId` | string | External market identifier |
 | `isYes` | boolean | `true` if this is a YES position, `false` for NO |
-| `contracts` | string | Number of contracts held (u64 as string) |
+| `contracts` | string | Legacy whole-contract quantity. Contracts are fractional: use `contractsMicro` (`1000000` = 1) or `contractsDecimal` for the exact amount |
+| `contractsMicro` | string | Contracts held in micro-contract units |
+| `contractsDecimal` | string | Contracts held as a decimal string |
 | `openOrders` | integer | Number of currently open orders for this position |
 | `claimable` | boolean | `true` when the position qualifies for payout claim |
 | `claimed` | boolean | Whether payout has already been claimed |
@@ -237,9 +239,10 @@ Use `GET /history` to retrieve a complete audit trail of all prediction market a
 | `order_created` | New order placed on-chain |
 | `order_filled` | Order matched and executed |
 | `order_failed` | Order could not be filled |
+| `order_closed` | Order account closed after completion |
 | `position_updated` | Position modified by order fill |
 | `position_lost` | Market resolved against position |
-| `payout_claimed` | Winnings withdrawn |
+| `payout_claimed` | Winnings withdrawn (also used when a position wins) |
 
 ### History Event Fields
 

--- a/prediction/social-features.mdx
+++ b/prediction/social-features.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Social Features"
-description: "Access user profiles, follow traders, view leaderboards, and track the global trade feed on Jupiter Prediction Market."
-llmsDescription: "GET /profiles/{pubkey} returns user stats. POST /follow and DELETE /unfollow manage relationships. GET /leaderboards returns rankings by pnl/volume/win_rate. GET /trades provides global trade feed."
+description: "Access user profiles, view leaderboards, and track the global trade feed on Jupiter Prediction Market."
+llmsDescription: "GET /profiles/{pubkey} returns user stats. GET /profiles/{pubkey}/pnl-history returns time-series P&L. GET /leaderboards returns rankings by pnl/volume/win_rate. GET /trades provides the global trade feed."
 ---
 
 <Note>
@@ -10,7 +10,7 @@ llmsDescription: "GET /profiles/{pubkey} returns user stats. POST /follow and DE
 The Prediction Market API is currently in beta and subject to breaking changes as we continue to improve the product. If you have any feedback, please reach out in [Discord](https://discord.gg/jup).
 </Note>
 
-This doc covers the social features of Jupiter Prediction Market, including user profiles, following system, leaderboards, and the global trade feed.
+This doc covers the social features of Jupiter Prediction Market: user profiles, leaderboards, and the global trade feed.
 
 ## Prerequisite
 
@@ -304,9 +304,5 @@ console.log('Top trader weekly P&L trend:', topTraderHistory.history);
 |:--------|:---------|:------------|
 | Profiles | `GET /profiles/{pubkey}` | User stats and performance |
 | P&L History | `GET /profiles/{pubkey}/pnl-history` | Time-series P&L data |
-| Follow | `POST /follow/{pubkey}` | Follow a trader |
-| Unfollow | `DELETE /unfollow/{pubkey}` | Unfollow a trader |
-| Followers | `GET /followers/{pubkey}` | List followers |
-| Following | `GET /following/{pubkey}` | List who user follows |
 | Trade Feed | `GET /trades` | Global recent trades |
 | Leaderboards | `GET /leaderboards` | Competitive rankings |


### PR DESCRIPTION
Fixes [DEV-427](https://linear.app/raccoons/issue/DEV-427/prediction-markets-docs-update) and [DEV-426](https://linear.app/raccoons/issue/DEV-426/add-live-scores-endpoint-to-developer-docs)

## What this is

Audited the Prediction Market docs and OpenAPI spec against the live API (`api.jup.ag/prediction/v1`) and the `jup-ag/prediction-market` source. Everything here is verified end-to-end (including a real buy/sell round-trip), and scoped to things that would actually mislead an integrator. Nothing in-flux or unreleased is documented.

## OpenAPI (`openapi-spec/prediction/prediction.yaml`)

- Markets come back flat, not nested under `metadata` — replaced the `metadata` ref with the real top-level fields. `resolveAt` is an ISO string once the market resolves.
- create-order / close responses were missing `requiredSigners`, `slippageBps`/`maxSlippageBps`, `payoutUsd`, and the fractional-contract fields (`contractsMicro`/`contractsDecimal`). Added `contractsMicro`/`contractsDecimal` as create-order request params too (only one quantity field allowed).
- `DELETE /positions` (close all) requires `minSellPriceSlippageBps` — marked required. Dropped the unused `CloseOrderResponse` schema.
- history `eventType` was missing `order_closed`; added the micro/decimal contract fields on history and claim.
- Added the live scores endpoints: `GET /events/scores` and `GET /events/{eventId}/score` + a `GameScore` schema. Also added the top-level `Event` fields `volume24hr` and `liveScore`.
- Smaller ones: `/events` `upcoming` filter + `tags` and `includeAllMarkets` params, `/events/search` returns `pagination`, `/orderbook` is sorted ascending, `/trades.id` is a string, `/profiles` micro/decimal fields, `/forecast` requires `marketId`, `/trading-status` wording.

## Docs

- **open-positions**: $5 minimum order (the example used $2, which fails), `created`/`partiallyfilled` statuses, fractional contracts.
- **events-and-markets**: flat market example, corrected result table, orderbook ordering, and a Live Scores section.
- **claim-payouts**: corrected the claim response example (`txMeta` + `positionPubkey`), removed the non-existent `settled`/`pending` states, noted auto-settling markets.
- **manage-positions**: documented the close-all `minSellPriceSlippageBps` requirement.
- **overview**: a Fractional Contracts section — `*Micro` for math, `*Decimal` for display, legacy fields are floored, parse `*Micro` with `BigInt`, 0.01-contract fill floor.
- Removed the follow / unfollow / followers / following api-reference pages — they pointed at OpenAPI paths that don't exist and rendered broken, and the social layer isn't shipped yet.

## Held back

Integrator fees (still returns 0), the follow/unfollow signed-message flow (unreleased), and a set of live-but-undocumented endpoints (parlays, tickets, `/execute`, order cancel/execute) — these need a scope call before documenting.

`llms.txt` regenerated, `mint broken-links` passes.
