### PR TITLE
chore: [platform] correct Linear team to Developer Platform in workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Before creating a new issue, search existing issues to avoid duplicates.
 
 Create a Linear issue for the work using the Linear MCP tools:
 - **Project:** `Docs` (ID: `docs-18ccf0a02c86`)
-- **Team:** `DevRel`
+- **Team:** `Developer Platform` (issues are prefixed `DEV-`)
 - **Title:** Action-oriented, specific — `[Area] Verb + what`
   - ✅ `[Ultra] Rewrite get-order page with complete code example`
   - ❌ `Update Ultra docs`


### PR DESCRIPTION
## Summary
The Track section of `AGENTS.md` (symlinked as `CLAUDE.md`) named the Linear team as `DevRel`. Issues are actually created and managed under the **Developer Platform** team (prefix `DEV-`) in the **Docs** project. This corrects the doc so contributors file issues under the right team.

## Changes
- `AGENTS.md` Track section: `Team: DevRel` → `Team: Developer Platform` (issues prefixed `DEV-`). Project unchanged (`Docs`).

## Notes
- Historical `DEVREL-NN` issue references in `.claude/rules/decisions.md` are intentionally left as-is — they are an accurate record of past work.

## Linear Issues
- Fixes [DEV-637](https://linear.app/raccoons/issue/DEV-637/platform-fix-stale-team-reference-in-agentsmdclaudemd-workflow) — Fix stale team reference in AGENTS.md/CLAUDE.md workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
