### PR TITLE
docs: [perps] add JupUSD custody to custody account page

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -420,7 +420,7 @@ Portfolio aggregation, Send (token transfers), Studio (token creation), and Lock
 - [Position Account](https://developers.jup.ag/docs/perps/position-account.md): The Position account stores trade position data including owner, side (long/short), entry price, size, collateral, PNL, and borrow fee snapshot. Derived from the trader's wallet, custody, and collateral custody.
 - [PositionRequest Account](https://developers.jup.ag/docs/perps/position-request-account.md): The PositionRequest account represents a pending request to open, close, or modify a position, including TP/SL triggers. It is a PDA derived from the Position account with a unique random seed.
 - [Pool Account](https://developers.jup.ag/docs/perps/pool-account.md): The Pool account stores JLP pool configuration including AUM (aumUsd), custody public keys, position limits, fee schedules (open/close/swap), and APR calculation data. Only one Pool account exists.
-- [Custody Account](https://developers.jup.ag/docs/perps/custody-account.md): The Custody account stores parameters and state for each token (SOL, ETH, BTC, USDC, USDT) managed by the JLP pool, including oracle data, pricing params, asset balances, and funding rate state.
+- [Custody Account](https://developers.jup.ag/docs/perps/custody-account.md): The Custody account stores parameters and state for each token (SOL, ETH, BTC, USDC, USDT, JupUSD) managed by the JLP pool, including oracle data, pricing params, asset balances, and funding rate state.
 
 ### API Reference
 

--- a/perps/custody-account.mdx
+++ b/perps/custody-account.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Custody Account"
 description: "Overview of the Custody account used in the Jupiter Perpetuals Program, representing tokens managed by the JLP pool"
-llmsDescription: "The Custody account stores parameters and state for each token (SOL, ETH, BTC, USDC, USDT) managed by the JLP pool, including oracle data, pricing params, asset balances, and funding rate state."
+llmsDescription: "The Custody account stores parameters and state for each token (SOL, ETH, BTC, USDC, USDT, JupUSD) managed by the JLP pool, including oracle data, pricing params, asset balances, and funding rate state."
 ---
 
 This page contains an overview of the  used in the Jupiter Perpetuals Program, and specifically the  account.
 
 The `Custody` account is a struct which represents a set of parameters and states associated to custodies (tokens) managed by the JLP pool which consists of the following custodies.
 
-| Custodies                                                                      |                                                                                |                                                                                |                                                                                 |                                                                                 |
-| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [SOL](https://solscan.io/account/7xS2gz2bTp3fwCC7knJvUWTEU9Tycczu6VhJYKgi1wdz) | [ETH](https://solscan.io/account/AQCGyheWPLeo6Qp9WpYS9m3Qj479t7R636N9ey1rEjEn) | [BTC](https://solscan.io/account/5Pv3gM9JrFFH883SWAhvJC9RPYmo8UNxuFtv5bMMALkm) | [USDC](https://solscan.io/account/G18jKKXQwBbrHeiK3C9MRXhkHsLHf7XgCSisykV46EZa) | [USDT](https://solscan.io/account/4vkNeXiYEUizLdrpdPS1eC2mccyM4NUPRtERrk6ZETkk) |
+| Custodies                                                                      |                                                                                |                                                                                |                                                                                 |                                                                                 |                                                                                    |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [SOL](https://solscan.io/account/7xS2gz2bTp3fwCC7knJvUWTEU9Tycczu6VhJYKgi1wdz) | [ETH](https://solscan.io/account/AQCGyheWPLeo6Qp9WpYS9m3Qj479t7R636N9ey1rEjEn) | [BTC](https://solscan.io/account/5Pv3gM9JrFFH883SWAhvJC9RPYmo8UNxuFtv5bMMALkm) | [USDC](https://solscan.io/account/G18jKKXQwBbrHeiK3C9MRXhkHsLHf7XgCSisykV46EZa) | [USDT](https://solscan.io/account/4vkNeXiYEUizLdrpdPS1eC2mccyM4NUPRtERrk6ZETkk) | [JupUSD](https://solscan.io/account/DdwY1ELc9rRK7xNL3hTXabSFBmVrTPpfsUZSv2Y3LL1U) |
 
 <Tip>
   This [repository](https://github.com/julianfssen/jupiter-perps-anchor-idl-parsing) contains Typescript code samples on interacting with the Jupiter Perpetuals program IDL with `anchor` and `@solana/web3.js`


### PR DESCRIPTION
## Summary

We added a new JupUSD custody to the JLP pool. This adds JupUSD to the Perps Custody Account docs so the list of custodies managed by the JLP pool is accurate.

## Changes

- `perps/custody-account.mdx`: add JupUSD to the Custodies table, linking to its custody account on Solscan (`DdwY1ELc9rRK7xNL3hTXabSFBmVrTPpfsUZSv2Y3LL1U`).
- `perps/custody-account.mdx`: add JupUSD to the `llmsDescription` token list.
- `llms.txt`: regenerated via `node generate-llms-from-docs.js` to reflect the updated `llmsDescription`.

JupUSD mint for reference: `JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD`. The table lists custody accounts (matching the existing SOL/ETH/BTC/USDC/USDT rows), so the custody account address is used.

## Checklist

- [x] `node generate-llms-from-docs.js` run
- [x] Page retains `title`, `description`, `llmsDescription`
- [ ] `mint broken-links` (not run locally; change only adds one well-formed external Solscan link)
