### PR TITLE
fix: [lend] fix borrow API reference pages not rendering

### DIFF
--- a/openapi-spec/lend/borrow.yaml
+++ b/openapi-spec/lend/borrow.yaml
@@ -556,9 +556,7 @@ components:
         ownerAddress:
           type: string
         vault:
-          oneOf:
-          - $ref: '#/components/schemas/BorrowVault'
-          - type: 'null'
+          $ref: '#/components/schemas/BorrowVault'
         config:
           type: object
           additionalProperties:


### PR DESCRIPTION
Follow-up nit to #918. The borrow API reference pages render blank because `openapi-spec/lend/borrow.yaml` used `type: 'null'` (OpenAPI 3.1) in a `3.0.3` spec, so Mintlify rejected the whole spec. Changed `BorrowPosition.vault` to a plain `$ref` (valid 3.0.3). Redocly validates clean and all four borrow pages render locally.

Fixes [DEV-688](https://linear.app/raccoons/issue/DEV-688/lend-fix-borrow-api-reference-pages-not-rendering-invalid-openapi-type)
