### PR TITLE
fix: [config] update banner to post-migration copy and revert to default banner colours

### DIFF
--- a/.claude/rules/product-learning.md
+++ b/.claude/rules/product-learning.md
@@ -187,6 +187,15 @@ source code > SDK/FE > docs). Keep it current as a side effect of documenting th
 
 ---
 
+# Mintlify Platform
+
+## Facts
+
+- [2026-07-08] Mintlify's compiled CSS is Tailwind v4 and puts utilities inside native cascade layers (`@layer utilities`). The banner (`div#banner`) forces its text colour with important utilities (`[&_*]:text-white/95!` → `color:#fffffff2!important` in `@layer utilities`) and sets `bg-primary-dark` (from `docs.json` `colors.dark`). Consequence for `style.css`: **layered `!important` beats unlayered `!important` regardless of specificity**, so unlayered custom overrides like `#banner * { color: black !important }` silently lose to Mintlify's layered important utilities, while unlayered important still beats their *normal* declarations (e.g. background). This produced the white-on-yellow banner fixed in DEV-723 (resolved by dropping the custom banner colours). If a custom override must beat a layered important utility, wrap it in `@layer utilities { ... }` so specificity applies again (an ID selector then outranks their class utilities). Verified against the deployed chunk `/docs/_next/static/chunks/f80c22dc4fd41578.css`.
+- [2026-07-08] `mint dev` local preview renders the banner and injects custom CSS client-side only, so curl/static inspection of the local HTML cannot verify banner styling; inspect the production/preview deployment HTML instead (prod inlines `style.css` as `<style data-custom-css-path="style.css">` and server-renders `div#banner`).
+
+---
+
 # AI Resources
 
 ## Facts

--- a/docs.json
+++ b/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "banner": {
-    "content": "The Jupiter Developer Platform is live. Previous portal users keep their rate limits for free until **30 June 2026** — set up billing on the [**new platform**](https://developers.jup.ag/portal) before then. See the [**Migration Guide**](/docs/portal/migration) for details."
+    "content": "Manage your API keys, billing, and usage on the [**Developer Platform**](https://developers.jup.ag/portal). Questions? Reach us via [**Support**](/docs/resources/support)."
   },
   "theme": "mint",
   "name": "Jupiter",

--- a/style.css
+++ b/style.css
@@ -6,14 +6,10 @@ th {
     color: white !important;
 }
 
-#banner {
-    background-color: #f2e584 !important;
-}
-#banner * {
-    color: black !important;
-    font-size: 0.75rem !important;
-    text-align: left;
-}
+/* Banner uses Mintlify default colours (bg from docs.json colors.dark, white text).
+   Custom colour overrides were removed: Mintlify's Tailwind v4 utilities set the
+   banner text colour with important declarations inside @layer utilities, which
+   beat unlayered important overrides regardless of specificity. */
 
 /* Hide dismiss button on desktop (show only on mobile) */
 @media screen and (min-width: 768px) {
@@ -23,9 +19,6 @@ th {
     #banner [data-dismiss],
     #banner button[type="button"] {
         display: none !important;
-    }
-    #banner {
-        text-align: center !important;
     }
 }
 


### PR DESCRIPTION
## Summary
The docs banner was rendering white text on our custom yellow (`#f2e584`) background. Mintlify's Tailwind v4 migration now forces the banner text colour with `!important` utilities inside `@layer utilities`, which beat our unlayered `!important` override regardless of specificity (our background override still won, producing white-on-yellow). Since the banner copy was also stale (the portal migration period ended 30 June 2026), we drop the custom banner colours entirely and use Mintlify defaults with new evergreen copy.

## Changes
- `docs.json`: banner copy replaced with post-migration copy linking the [Developer Platform](https://developers.jup.ag/portal) and the [Support page](https://developers.jup.ag/docs/resources/support)
- `style.css`: removed `#banner` background/colour/font-size overrides (banner now uses Mintlify defaults: background from `colors.dark` `#000000`, white text) and the centering rule that only existed to counter the removed left-align; kept the desktop dismiss-button hiding

## Linear Issues
- Fixes [DEV-723](https://linear.app/raccoons/issue/DEV-723) — [Config] Update banner to post-migration copy and revert to default banner colours

## Checklist
- [x] `node generate-llms-from-docs.js` run (no diff — no frontmatter changes)
- [x] `mint broken-links` passes
- [x] All pages have `title`, `description`, `llmsDescription` (no page changes)
- [x] `docs.json` navigation updated (n/a — banner content only)
- [x] Redirects added (n/a — no path changes)
- [x] Changelog entry added to `updates/index.mdx` (n/a — site chrome, not an API/product change)
- [x] `.claude/rules/` updated with any learnings or decisions
