### PR TITLE
fix: [config] remove stale trigger redirects shadowing V2 create-order and cancel-order pages

### DIFF
--- a/.claude/rules/decisions.md
+++ b/.claude/rules/decisions.md
@@ -132,9 +132,9 @@ Track all redirects added to `vercel.json` here for visibility:
 
 | Old Path | New Path | Date | Reason |
 |----------|----------|------|--------|
-| `/api-reference/trigger/create-order` | `/api-reference/trigger/v1/create-order` | 2026-03-10 | V1/V2 restructure (DEVREL-75) |
+| `/api-reference/trigger/create-order` | `/api-reference/trigger/v1/create-order` | 2026-03-10 | V1/V2 restructure (DEVREL-75). REMOVED 2026-07-09 (DEV-724): after DEVREL-115 the V2 page lives at the unprefixed URL, so this redirect shadowed it. Unprefixed URL now serves V2. |
 | `/api-reference/trigger/execute` | `/api-reference/trigger/v1/execute` | 2026-03-10 | V1/V2 restructure (DEVREL-75) |
-| `/api-reference/trigger/cancel-order` | `/api-reference/trigger/v1/cancel-order` | 2026-03-10 | V1/V2 restructure (DEVREL-75) |
+| `/api-reference/trigger/cancel-order` | `/api-reference/trigger/v1/cancel-order` | 2026-03-10 | V1/V2 restructure (DEVREL-75). REMOVED 2026-07-09 (DEV-724): same shadowing as create-order. |
 | `/api-reference/trigger/cancel-orders` | `/api-reference/trigger/v1/cancel-orders` | 2026-03-10 | V1/V2 restructure (DEVREL-75) |
 | `/api-reference/trigger/get-trigger-orders` | `/api-reference/trigger/v1/get-trigger-orders` | 2026-03-10 | V1/V2 restructure (DEVREL-75) |
 | `/ai/ecosystem` | `/ai` | 2026-03-23 | Ecosystem page removed in AI section rework (PR #857) |

--- a/docs.json
+++ b/docs.json
@@ -798,16 +798,8 @@
       "destination": "/api-reference/tokens/:slug*"
     },
     {
-      "source": "/api-reference/trigger/cancel-order",
-      "destination": "/api-reference/trigger/v1/cancel-order"
-    },
-    {
       "source": "/api-reference/trigger/cancel-orders",
       "destination": "/api-reference/trigger/v1/cancel-orders"
-    },
-    {
-      "source": "/api-reference/trigger/create-order",
-      "destination": "/api-reference/trigger/v1/create-order"
     },
     {
       "source": "/api-reference/trigger/execute",


### PR DESCRIPTION
## Summary

The Trigger V2 API reference sidebar entries for "Create Order" and "Cancel Order" landed on the V1 pages. Two redirects added during the 2026-03-10 V1/V2 restructure (DEVREL-75) still mapped the unprefixed trigger paths to `v1/*`; after the 2026-03-23 nav restructure (DEVREL-115) placed the V2 pages at those same unprefixed URLs, the redirects fired before the live V2 pages were served. This removes the two stale redirects.

## Changes

- `docs.json`: removed two redirects, `/api-reference/trigger/create-order` → `v1/create-order` and `/api-reference/trigger/cancel-order` → `v1/cancel-order`. The unprefixed URLs now serve the V2 pages, matching the sitewide "unprefixed = latest" convention. The other three V1 trigger redirects (`cancel-orders`, `execute`, `get-trigger-orders`) are untouched; no V2 page occupies those URLs.
- `.claude/rules/decisions.md`: annotated the Redirect Log entries with the removal and reason.

Swept all redirect sources against files on disk: no other redirect shadows a live page.

## Linear Issues

- Fixes [DEV-724](https://linear.app/raccoons/issue/DEV-724/config-remove-stale-trigger-redirects-shadowing-v2-create-order-and) — [Config] Remove stale trigger redirects shadowing V2 create-order and cancel-order pages

## Checklist

- [x] `node generate-llms-from-docs.js` run (no diff, no content changed)
- [x] `mint broken-links` passes
- [x] All pages have `title`, `description`, `llmsDescription` (no pages touched)
- [x] `docs.json` navigation updated (n/a, redirects only)
- [x] Redirects added (n/a, redirects removed; removal logged)
- [x] Changelog entry added to `updates/index.mdx` (not needed, docs config fix)
- [x] `.claude/rules/` updated with any learnings or decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
