### PR TITLE
docs(latency): link OpenChainBench public Solana DEX quote latency benchmark

### DIFF
--- a/portal/latency.mdx
+++ b/portal/latency.mdx
@@ -28,3 +28,7 @@ If your users are globally distributed:
 - **Asia-Pacific:** Singapore (`ap-southeast-1`) or Tokyo (`ap-northeast-1`)
 - **Europe:** Frankfurt (`eu-central-1`)
 - **Americas:** Virginia (`us-east-1`), Oregon (`us-west-2`), or São Paulo (`sa-east-1`)
+
+## Public latency benchmarks
+
+If you want to verify quote-path latency from your own region before colocating, [OpenChainBench](https://openchainbench.com/benchmarks/solana-dex-quote-latency) publishes an open, multi-region latency benchmark for Solana DEX aggregators. It probes the quote API on Jupiter, Raydium, OpenOcean and Mobula every 60 seconds from Paris, Virginia and Singapore, and tracks p50 / p95 wall-clock latency plus response success rate. Methodology and raw data are open-source ([source](https://github.com/ChainBench/openchainbench)).


### PR DESCRIPTION
## Summary

Adds a short subsection at the end of `portal/latency.mdx` linking to a public, multi-region benchmark of Solana DEX quote APIs. The page already documents Jupiter's own gateway regions and colocation guidance; this reference gives integrators an independent way to compare quote latency from their own region before committing to colocation.

## What it links to

[OpenChainBench / solana-dex-quote-latency](https://openchainbench.com/benchmarks/solana-dex-quote-latency) — an open-source ([ChainBench/openchainbench](https://github.com/ChainBench/openchainbench)) probe run from Paris (eu-west), Virginia (us-east) and Singapore (ap-southeast). It:

- Calls the quote API on Jupiter, Raydium, OpenOcean and Mobula every 60 seconds from all 3 regions.
- Publishes p50 / p95 wall-clock request latency and success rate.
- Rolls up 24 h / 7 d / 30 d views with methodology and raw JSON.

No API keys, no signup, no paywall.

## Why here

This page is the canonical answer for "where is Jupiter's API fastest for me?". A single-line reference to a neutral, open benchmark lets integrators cross-check their own numbers instead of relying purely on ping tests to the gateway regions.

## Notes

- Diff is 4 lines, 1 file.
- I don't work at any of the providers on the benchmark; happy to reword if the phrasing reads as promotional.