### PR TITLE
feat: [config] add redirect conflict detection script

### DIFF
--- a/.claude/rules/decisions.md
+++ b/.claude/rules/decisions.md
@@ -247,6 +247,7 @@ Track all redirects added to `vercel.json` here for visibility:
 | `/docs/trigger/*` | `/trigger/*` | 2026-03-28 | Product folders moved to root (DEVREL-133) |
 | `/docs/ultra/*` | `/ultra/*` | 2026-03-28 | Product folders moved to root (DEVREL-133) |
 | `/changelog` | `https://developers.jup.ag/changelog` | 2026-07-15 | Changelog consolidated on dev platform blog. `docs.json` redirect with an external destination; Mintlify's schema only documents internal paths, so verify in prod after deploy (DEV-718) |
+| `/api-reference/trigger/v2` | `/api-reference/trigger/challenge` | 2026-08-03 | Destination fix (BUILD-472): previously pointed at `/api-reference/trigger/index`, which 404s in prod (no such page). Repointed to the first Trigger V2 API reference page, matching the `/api-reference/swap/v1` → `.../quote` pattern. Caught by `check-redirects.js` on its first run |
 
 ### [2026-04-06] Hidden pages for private integrator docs
 **Status:** implemented

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,8 +142,9 @@ Create a Linear issue for the work using the Linear MCP tools:
   - Files affected — explicit list
   - Acceptance criteria — checkbox list so it's clear when the task is done
   - Out of scope — what this issue does NOT cover
-- **Labels** from the Build team's label set where one fits (e.g. `Feature` for new content or tooling, `Chore` for config and cleanup, `Content` for content work); skip labels if none fit
 - **Initial status:** `Todo` (work is planned but not yet actively being worked on)
+
+No labels needed — the issue just needs to be under the `Docs` project on the `Build` team.
 
 If the work breaks down into distinct, self-contained pieces, create sub-issues
 under the parent. Each sub-issue should be independently completable — a clear
@@ -441,7 +442,7 @@ Always run/check before committing:
 
 1. `node generate-llms-from-docs.js` — regenerate llms.txt
 2. `mint broken-links` — check for broken links
-3. `node check-redirects.js` — check `docs.json` redirects for conflicts, chains, and shadowed pages
+3. `node check-redirects.js` — only if you added or changed a redirect in `docs.json`; checks for conflicts, chains, and shadowed pages
 4. `docs.json` is valid JSON
 5. Any new pages are added to `docs.json` navigation
 6. All new/updated pages have `title`, `description`, AND `llmsDescription`
@@ -493,7 +494,7 @@ gh pr diff
 ## Checklist
 - [ ] `node generate-llms-from-docs.js` run
 - [ ] `mint broken-links` passes
-- [ ] `node check-redirects.js` passes
+- [ ] `node check-redirects.js` passes (if redirects changed)
 - [ ] All pages have `title`, `description`, `llmsDescription`
 - [ ] `docs.json` navigation updated (if applicable)
 - [ ] Redirects added (if paths changed)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ Before creating a new issue, search existing issues to avoid duplicates.
 
 Create a Linear issue for the work using the Linear MCP tools:
 - **Project:** `Docs` (ID: `docs-18ccf0a02c86`)
-- **Team:** `Developer Platform` (issues are prefixed `DEV-`)
+- **Team:** `Build` (issues are prefixed `BUILD-`)
 - **Title:** Action-oriented, specific — `[Area] Verb + what`
   - ✅ `[Ultra] Rewrite get-order page with complete code example`
   - ❌ `Update Ultra docs`
@@ -142,9 +142,7 @@ Create a Linear issue for the work using the Linear MCP tools:
   - Files affected — explicit list
   - Acceptance criteria — checkbox list so it's clear when the task is done
   - Out of scope — what this issue does NOT cover
-- **Labels** from this taxonomy:
-  - Area: `ultra`, `swap`, `tokens`, `price`, `routing`, `toolkits`, `portal`, `platform`, `ai`, `guides`, `get-started`
-  - Type: `content-new`, `content-update`, `restructure`, `cleanup`, `config`
+- **Labels** from the Build team's label set where one fits (e.g. `Feature` for new content or tooling, `Chore` for config and cleanup, `Content` for content work); skip labels if none fit
 - **Initial status:** `Todo` (work is planned but not yet actively being worked on)
 
 If the work breaks down into distinct, self-contained pieces, create sub-issues
@@ -219,7 +217,7 @@ entry is part of shipping, not a follow-up. As soon as the docs PR is open:
    as a sibling of this repo: `git clone https://github.com/jup-ag/developer-platform.git`.
 2. Branch from `origin/develop` and open the PR against `develop` (the integration branch:
    pushes to it build the staging site, and production ships when a `web-v*` release is cut).
-   Branch naming: `<user>/dev-XXX-description` matching the Linear issue.
+   Branch naming: `<user>/build-XXX-description` matching the Linear issue.
 3. Add or update the current month's post in `web/content/changelog/`. Follow the format in
    `web/content/changelog/_template.mdx` and the rules in `web/content/blog/README.md`
    (breaking changes first, one section per product area, each entry a `<ChangelogItem>`
@@ -261,7 +259,7 @@ Once the work is ready:
 - Run through the Reviewing and Pre-Commit checklists
 - Commit and push the branch
 - Open a PR via `gh` CLI
-- Reference the Linear issue in the PR body with a link: `Fixes [DEV-XX](https://linear.app/raccoons/issue/DEV-XX)`
+- Reference the Linear issue in the PR body with a link: `Fixes [BUILD-XX](https://linear.app/raccoons/issue/BUILD-XX)`
 - If the change affects a public API or product, open the companion changelog PR in the
   `developer-platform` repo now and attach it to the same Linear issue (see Changelog in §5)
 - Update the Linear issue to `In Review`
@@ -443,14 +441,15 @@ Always run/check before committing:
 
 1. `node generate-llms-from-docs.js` — regenerate llms.txt
 2. `mint broken-links` — check for broken links
-3. `docs.json` is valid JSON
-4. Any new pages are added to `docs.json` navigation
-5. All new/updated pages have `title`, `description`, AND `llmsDescription`
-6. No placeholder text like "TODO" or "Lorem ipsum" left in content
-7. OpenAPI spec changes in `openapi-spec/` are reflected in `api-reference/` pages
-8. Images/assets added to `static/` are actually referenced somewhere
-9. Changelog entry added to the current month's post in the `developer-platform` repo (`web/content/changelog/YYYY-MM.mdx`) if changes affect a public API or product
-10. `.claude/rules/` updated if you discovered product behaviour, made IA decisions, or established conventions
+3. `node check-redirects.js` — check `docs.json` redirects for conflicts, chains, and shadowed pages
+4. `docs.json` is valid JSON
+5. Any new pages are added to `docs.json` navigation
+6. All new/updated pages have `title`, `description`, AND `llmsDescription`
+7. No placeholder text like "TODO" or "Lorem ipsum" left in content
+8. OpenAPI spec changes in `openapi-spec/` are reflected in `api-reference/` pages
+9. Images/assets added to `static/` are actually referenced somewhere
+10. Changelog entry added to the current month's post in the `developer-platform` repo (`web/content/changelog/YYYY-MM.mdx`) if changes affect a public API or product
+11. `.claude/rules/` updated if you discovered product behaviour, made IA decisions, or established conventions
 
 ## Pull Requests
 
@@ -488,12 +487,13 @@ gh pr diff
 
 ## Linear Issues
 {Link each issue with its Linear URL}
-- Fixes [DEV-XX](https://linear.app/raccoons/issue/DEV-XX) — {issue title}
-- Fixes [DEV-XX](https://linear.app/raccoons/issue/DEV-XX) — {issue title}
+- Fixes [BUILD-XX](https://linear.app/raccoons/issue/BUILD-XX) — {issue title}
+- Fixes [BUILD-XX](https://linear.app/raccoons/issue/BUILD-XX) — {issue title}
 
 ## Checklist
 - [ ] `node generate-llms-from-docs.js` run
 - [ ] `mint broken-links` passes
+- [ ] `node check-redirects.js` passes
 - [ ] All pages have `title`, `description`, `llmsDescription`
 - [ ] `docs.json` navigation updated (if applicable)
 - [ ] Redirects added (if paths changed)
@@ -517,7 +517,8 @@ references, bookmarks, and indexed search results. The cost is always higher tha
   1. Add a redirect in `docs.json` (under the `redirects` array)
   2. Update all internal links repo-wide (`grep` for the old path)
   3. Run `mint broken-links` and confirm zero breakage
-  4. Note the redirect in `.claude/rules/decisions.md` under the Redirect Log
+  4. Run `node check-redirects.js` and confirm the new redirect introduces no conflicts or chains
+  5. Note the redirect in `.claude/rules/decisions.md` under the Redirect Log
 - If you're unsure whether a rename is worth it, **don't do it** — ask the user.
 
 ## Unmaintained Pages

--- a/check-redirects.js
+++ b/check-redirects.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * check-redirects.js — validate the `redirects` array in docs.json.
+ *
+ * Detects:
+ *   1. Duplicate source paths
+ *   2. Self-redirects (source === destination)
+ *   3. Sources that shadow a live page (a page in docs.json navigation, or any
+ *      .mdx/.md file on disk — Mintlify serves every file at its URL path, and
+ *      a redirect takes precedence over the page, silently hiding it)
+ *   4. Redirect chains (A -> B where B is itself a redirect source)
+ *   5. Internal destinations that do not resolve to a live page or another
+ *      redirect (warning only — likely a typo or a deleted page)
+ *
+ * Wildcard sources/destinations use the `:slug*` suffix. This script treats
+ * `:slug*` as one-or-more path segments, matching how the redirects in this
+ * repo are written (exact-path entries exist alongside their wildcard
+ * variants, e.g. `/updates` and `/updates/:slug*`).
+ *
+ * Usage: node check-redirects.js
+ * Exit code: 1 if any error is found, 0 otherwise (warnings do not fail).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = __dirname;
+const docsJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'docs.json'), 'utf8'));
+
+// Intentional chains, documented in .claude/rules/decisions.md.
+// Format: [source, matched redirect source it chains into]
+const ALLOWED_CHAINS = [
+  // /updates -> /changelog -> https://developers.jup.ag/changelog
+  // Kept deliberately when the changelog moved to the dev platform (DEV-595, DEV-718).
+  ['/updates', '/changelog'],
+];
+
+// ---------------------------------------------------------------------------
+// Collect live page paths
+// ---------------------------------------------------------------------------
+
+// From docs.json navigation: every string entry in a `pages` array is a page.
+function collectNavPages(node, out) {
+  if (typeof node === 'string') {
+    out.add('/' + node.replace(/^\//, ''));
+    // `x/index` is also served at `/x`
+    if (node.endsWith('/index')) out.add('/' + node.slice(0, -'/index'.length));
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) collectNavPages(item, out);
+    return;
+  }
+  if (node && typeof node === 'object') {
+    for (const key of ['navigation', 'tabs', 'groups', 'pages', 'menu', 'items', 'anchors']) {
+      if (node[key]) collectNavPages(node[key], out);
+    }
+  }
+}
+
+// From the filesystem: Mintlify serves EVERY .md/.mdx file at its URL path,
+// whether or not it is in the navigation (unmaintained pages rely on this).
+function collectFilePages(dir, out) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectFilePages(full, out);
+    } else if (/\.mdx?$/.test(entry.name)) {
+      const rel = path.relative(ROOT, full).replace(/\.mdx?$/, '');
+      out.add('/' + rel);
+      if (rel.endsWith('/index')) out.add('/' + rel.slice(0, -'/index'.length));
+    }
+  }
+}
+
+const navPages = new Set();
+collectNavPages(docsJson.navigation, navPages);
+const filePages = new Set();
+collectFilePages(ROOT, filePages);
+
+// ---------------------------------------------------------------------------
+// Redirect helpers
+// ---------------------------------------------------------------------------
+
+const redirects = docsJson.redirects || [];
+
+const isExternal = (p) => /^https?:\/\//.test(p);
+const isWildcard = (p) => p.includes(':slug*');
+const wildcardBase = (p) => p.slice(0, p.indexOf('/:slug*'));
+
+// Does a concrete path match a redirect source (exact or wildcard)?
+function matchingSource(concretePath) {
+  for (const r of redirects) {
+    if (isWildcard(r.source)) {
+      const base = wildcardBase(r.source);
+      if (concretePath.startsWith(base + '/')) return r.source;
+    } else if (r.source === concretePath) {
+      return r.source;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+const errors = [];
+const warnings = [];
+
+// 1. Duplicate sources
+const seen = new Map();
+for (const r of redirects) {
+  if (seen.has(r.source)) {
+    errors.push(`duplicate source: ${r.source} -> ${r.destination} (also -> ${seen.get(r.source)})`);
+  } else {
+    seen.set(r.source, r.destination);
+  }
+}
+
+for (const r of redirects) {
+  const { source, destination } = r;
+
+  // 2. Self-redirect
+  if (source === destination) {
+    errors.push(`self-redirect: ${source} -> ${destination}`);
+    continue;
+  }
+
+  // 3. Source shadows a live page
+  if (isWildcard(source)) {
+    const base = wildcardBase(source);
+    const shadowed = [...new Set([...navPages, ...filePages])].filter((p) => p.startsWith(base + '/'));
+    for (const p of shadowed) {
+      errors.push(`wildcard source ${source} shadows live page ${p} (redirects win over pages)`);
+    }
+  } else {
+    if (navPages.has(source)) {
+      errors.push(`source ${source} is a live page in docs.json navigation (redirect shadows it)`);
+    } else if (filePages.has(source)) {
+      errors.push(`source ${source} is a live file on disk (redirect shadows it, page becomes unreachable)`);
+    }
+  }
+
+  // 4. Chains: destination is itself a redirect source
+  if (!isExternal(destination)) {
+    // A wildcard destination resolves to concrete paths under its base; only
+    // its base-with-a-segment form can match another source, so check the base
+    // pattern itself against wildcard sources and skip exact-source matching.
+    const dest = isWildcard(destination) ? null : destination;
+    if (dest) {
+      const hit = matchingSource(dest);
+      if (hit && hit !== source) {
+        const allowed = ALLOWED_CHAINS.some(([s, via]) => s === source && via === hit);
+        if (!allowed) {
+          errors.push(`redirect chain: ${source} -> ${destination} -> (${hit} -> ${seen.get(hit)})`);
+        }
+      }
+
+      // 5. Destination resolves to nothing (warning)
+      if (!hit && !navPages.has(dest) && !filePages.has(dest)) {
+        warnings.push(`destination ${dest} (from ${source}) is not a live page or redirect — possible typo or deleted page`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+console.log(`check-redirects: ${redirects.length} redirects, ${navPages.size} nav paths, ${filePages.size} file paths\n`);
+
+if (warnings.length) {
+  console.log(`⚠ ${warnings.length} warning(s):`);
+  for (const w of warnings) console.log(`  - ${w}`);
+  console.log('');
+}
+
+if (errors.length) {
+  console.log(`✖ ${errors.length} error(s):`);
+  for (const e of errors) console.log(`  - ${e}`);
+  process.exit(1);
+}
+
+console.log('✔ no redirect conflicts found');

--- a/docs.json
+++ b/docs.json
@@ -809,7 +809,7 @@
     },
     {
       "source": "/api-reference/trigger/v2",
-      "destination": "/api-reference/trigger/index"
+      "destination": "/api-reference/trigger/challenge"
     },
     {
       "source": "/api-reference/trigger/v2/:slug*",


### PR DESCRIPTION
## Summary
Adds `check-redirects.js`, a zero-dependency validator for the `redirects` array in `docs.json`. As version paths get unnested (e.g. `/api-reference/price/v3/price` → `/api-reference/price`), stale redirects can shadow future pages; this script catches that class of bug before it ships.

## Changes
- **`check-redirects.js` (new)** — detects: duplicate source paths, self-redirects, sources that shadow a live page (docs.json nav or any `.mdx`/`.md` file on disk, since Mintlify serves every file), redirect chains (A → B → C, with an allowlist for the intentional `/updates` → `/changelog` → external chain from DEV-595), and dead internal destinations (warning). Wildcard `:slug*` sources are supported. Exit code 1 on errors.
- **`docs.json`** — fixes a real bug the script caught: `/api-reference/trigger/v2` redirected to `/api-reference/trigger/index`, which 404s in production. Now points to `/api-reference/trigger/challenge` (first Trigger V2 API reference page, same pattern as `/api-reference/swap/v1` → `.../quote`).
- **`AGENTS.md`** — added `node check-redirects.js` to the pre-commit checklist, the path-change steps, and the PR checklist template. Also updated the Linear workflow section to the current setup: docs issues live on the **Build** team (`BUILD-` prefix), with the Build team's label set.

## Linear Issues
- Fixes [BUILD-472](https://linear.app/raccoons/issue/BUILD-472) — [Config] Add redirect conflict detection script

## Checklist
- [x] `node generate-llms-from-docs.js` run (no diff — no content pages changed)
- [x] `mint broken-links` passes
- [x] `node check-redirects.js` passes (zero conflicts on current docs.json)
- [ ] All pages have `title`, `description`, `llmsDescription` (n/a — no pages touched)
- [ ] `docs.json` navigation updated (n/a)
- [ ] Redirects added (n/a — one broken destination fixed, no path changes)
- [ ] Changelog entry (n/a — internal tooling, no public API change)
- [x] `.claude/rules/` — no new learnings beyond what's already recorded
