### PR TITLE
docs: [resources] add Security page for the bug bounty program

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -662,6 +662,7 @@
               "resources/brand-kit",
               "resources/stats",
               "resources/audits",
+              "resources/security",
               "resources/references"
             ]
           },

--- a/llms.txt
+++ b/llms.txt
@@ -492,7 +492,8 @@ Support channels, brand assets, and community resources.
 - [Support](https://developers.jup.ag/docs/resources/support.md): Technical and customer support platforms for Jupiter
 - [Brand Kit](https://developers.jup.ag/docs/resources/brand-kit.md): Logos, labelling guidelines, and brand assets for Jupiter integrations.
 - [Stats](https://developers.jup.ag/docs/resources/stats.md): Jupiter product metrics, revenue, and usage statistics on Dune.
-- [Audits](https://developers.jup.ag/docs/resources/audits.md): Formal audit reports for Jupiter programs
+- [Audits](https://developers.jup.ag/docs/resources/audits.md): Formal third-party audit reports for Jupiter's onchain programs, organised by product: Jupiter Swap, Perpetuals, Lend, Limit Order, Lock, and DAO. Each entry links to the full PDF report from firms including Offside Labs, OtterSec, Sec3, Certora, Code4rena, Mixbytes, and Zenith. To report a new vulnerability, use the bug bounty program on the Security page instead.
+- [Security](https://developers.jup.ag/docs/resources/security.md): How to report security vulnerabilities in Jupiter's onchain programs, APIs, and web infrastructure. Jupiter runs a public bug bounty program at security.jup.ag with separate Web3 and Web2 tracks, rewarding vulnerabilities that threaten user funds, protocol solvency, governance integrity, or user data. Links to the formal audit reports for Jupiter programs.
 - [References](https://developers.jup.ag/docs/resources/references.md): Links and references to Jupiter's GitHub repositories.
 
 ### Legal

--- a/resources/audits.mdx
+++ b/resources/audits.mdx
@@ -1,9 +1,10 @@
 ---
 title: "Audits"
 description: "Formal audit reports for Jupiter programs"
+llmsDescription: "Formal third-party audit reports for Jupiter's onchain programs, organised by product: Jupiter Swap, Perpetuals, Lend, Limit Order, Lock, and DAO. Each entry links to the full PDF report from firms including Offside Labs, OtterSec, Sec3, Certora, Code4rena, Mixbytes, and Zenith. To report a new vulnerability, use the bug bounty program on the Security page instead."
 ---
 
-Jupiter protocols are audited by reputable security firms to ensure the highest level of security and reliability. The following section provides the audits of Jupiter's protocols.
+Jupiter protocols are audited by reputable security firms to ensure the highest level of security and reliability. The following section provides the audits of Jupiter's protocols. To report a vulnerability, use the bug bounty program listed on the [Security](/resources/security) page.
 
 ## Jupiter Swap
 

--- a/resources/security.mdx
+++ b/resources/security.mdx
@@ -1,0 +1,29 @@
+---
+title: "Security"
+description: "Report vulnerabilities through Jupiter's bug bounty program"
+llmsDescription: "How to report security vulnerabilities in Jupiter's onchain programs, APIs, and web infrastructure. Jupiter runs a public bug bounty program at security.jup.ag with separate Web3 and Web2 tracks, rewarding vulnerabilities that threaten user funds, protocol solvency, governance integrity, or user data. Links to the formal audit reports for Jupiter programs."
+---
+
+Jupiter runs a public bug bounty program for security researchers. If you find a vulnerability in Jupiter's onchain programs, APIs, or web infrastructure, report it through the program rather than disclosing it publicly.
+
+## Bug bounty program
+
+The program lives at [security.jup.ag](https://security.jup.ag) and is split into two tracks:
+
+- **Web3**: Jupiter's onchain programs and protocol infrastructure
+- **Web2**: web applications, APIs, and supporting infrastructure
+
+Rewards are reserved for vulnerabilities that materially threaten user funds, protocol solvency, governance integrity, or user data. Theoretical issues and deviations from best practice are out of scope. The program page lists the full asset scope, reward tiers, and rules of engagement.
+
+Good-faith research conducted under the program guidelines is not subject to legal action.
+
+## Reporting a vulnerability
+
+1. Read the scope and rules at [security.jup.ag](https://security.jup.ag).
+2. Submit your report through the program page with reproduction steps and impact assessment.
+3. Do not disclose the vulnerability publicly until the report is resolved.
+
+## Related
+
+- [Audits](/resources/audits): formal audit reports for Jupiter programs
+- [Support](/resources/support): developer support channels for non-security issues


### PR DESCRIPTION
## Summary
Jupiter's security/bug bounty program lives at [security.jup.ag](https://security.jup.ag) (redirects to the program page on ooosec.com) but the docs never mentioned it. This adds a Security page to the Resources tab so developers and researchers can find the reporting path, next to the existing Audits page.

## Changes
- **`resources/security.mdx` (new)** — what the bug bounty program covers (Web3 and Web2 tracks), what qualifies for rewards, and how to report. Deliberately thin: scope, reward tiers, and rules stay on the program page so the docs can't drift from them.
- **`docs.json`** — added `resources/security` to the Resources group, after Audits.
- **`resources/audits.mdx`** — cross-link to the Security page for vulnerability reporting, plus an `llmsDescription` (the page had none).
- **`llms.txt`** — regenerated (240 entries).

## Linear Issues
- Fixes [BUILD-487](https://linear.app/raccoons/issue/BUILD-487) — Add security sites to dev platform/docs

## Checklist
- [x] `node generate-llms-from-docs.js` run
- [x] `mint broken-links` passes
- [x] All new/updated pages have `title`, `description`, `llmsDescription`
- [x] `docs.json` navigation updated
- [ ] Redirects added (n/a — new page, no path changes)
- [ ] Changelog entry (n/a — resources content, not an API/product change)
- [x] `.claude/rules/` — no new product learnings
