### PR TITLE
fix: [config] update footer YouTube link to @JupiterOnchain

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -696,7 +696,7 @@
       "discord": "https://discord.gg/jup",
       "telegram": "https://t.me/jup_dev",
       "github": "https://github.com/jup-ag",
-      "youtube": "https://www.youtube.com/@Jupiter-Exchange"
+      "youtube": "https://www.youtube.com/@JupiterOnchain"
     },
     "links": [
       {


### PR DESCRIPTION
## Summary
The Jupiter YouTube channel was rebranded from `@Jupiter-Exchange` to `@JupiterOnchain` (jup.ag was already updated in UI-478). The docs site footer still pointed to the old handle.

## Changes
- `docs.json` — `footer.socials.youtube` now points to https://www.youtube.com/@JupiterOnchain. Verified no other `@Jupiter-Exchange` references remain in the repo.

## Linear Issues
- Fixes [BUILD-757](https://linear.app/raccoons/issue/BUILD-757) — [Config] Update footer YouTube link to @JupiterOnchain

## Checklist
- [x] `node generate-llms-from-docs.js` run (no diff — footer config only)
- [ ] `mint broken-links` (n/a — external link change only)
- [ ] All pages have `title`, `description`, `llmsDescription` (n/a — no pages touched)
- [ ] `docs.json` navigation updated (n/a)
- [ ] Redirects added (n/a)
- [ ] Changelog entry (n/a — no API/product change)
